### PR TITLE
[Badge Fix] fix termux Discord server ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Termux:X11
 
-[![Nightly build](https://github.com/termux/termux-x11/actions/workflows/debug_build.yml/badge.svg?branch=master)](https://github.com/termux/termux-x11/actions/workflows/debug_build.yml) [![Join the chat at https://gitter.im/termux/termux](https://badges.gitter.im/termux/termux.svg)](https://gitter.im/termux/termux) [![Join the Termux discord server](https://img.shields.io/discord/591914197219016707.svg?label=&logo=discord&logoColor=ffffff&color=5865F2)](https://discord.gg/HXpF69X)
+[![Nightly build](https://github.com/termux/termux-x11/actions/workflows/debug_build.yml/badge.svg?branch=master)](https://github.com/termux/termux-x11/actions/workflows/debug_build.yml) [![Join the chat at https://gitter.im/termux/termux](https://badges.gitter.im/termux/termux.svg)](https://gitter.im/termux/termux) [![Join the Termux discord server](https://img.shields.io/discord/641256914684084234?label=&logo=discord&logoColor=ffffff&color=5865F2)](https://discord.gg/HXpF69X)
 
 A [Termux](https://termux.com) add-on app providing Android frontend for Xwayland.
 


### PR DESCRIPTION
found that shield badge showing read badge cause incorrect SERVER ID and watching the same from ( like ~6 days )
![image](https://user-images.githubusercontent.com/68287637/140456065-9a5f0359-361a-41ff-a5cd-e15dd9bc0b87.png)

so I fixed it!

But 
![image](https://user-images.githubusercontent.com/68287637/140456321-758e000c-a0a9-412d-9cf9-28dd454e9006.png)
to fix that grey badge discord admins need to enable widgets in discord server settings so that it shows the number of people online

have a nice day developing termux-x11