### PR TITLE
Added: Auto launch fullscreen on external display (Android 10+)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,6 @@
             android:enabled="true"
             android:exported="false"/>
         <activity android:name=".MainActivity"
-            android:theme="@style/NoActionBar"
             android:launchMode="singleInstance"
             android:supportsPictureInPicture="true"
             android:configChanges="fontScale|orientation|screenSize|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|screenLayout|touchscreen|uiMode|smallestScreenSize|density"

--- a/app/src/main/java/com/termux/x11/MainActivity.java
+++ b/app/src/main/java/com/termux/x11/MainActivity.java
@@ -5,11 +5,8 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.os.Build;
-import android.preference.PreferenceManager;
-
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.view.KeyEvent;
 import android.view.PointerIcon;
 import android.view.SurfaceView;
@@ -19,9 +16,13 @@ import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.FrameLayout;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
 import com.termux.x11.utils.PermissionUtils;
 
 public class MainActivity extends AppCompatActivity {
+    static final String REQUEST_LAUNCH_EXTERNAL_DISPLAY = "request_launch_external_display";
 
     private static int[] keys = {
             KeyEvent.KEYCODE_ESCAPE,
@@ -39,6 +40,10 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (didRequestLaunchExternalDisplay()) {
+            setFullScreenForExternalDisplay();
+        }
 
         LorieService.setMainActivity(this);
         LorieService.start(LorieService.ACTION_START_FROM_ACTIVITY);
@@ -62,6 +67,27 @@ public class MainActivity extends AppCompatActivity {
         if (i != null && i.getBooleanExtra(LorieService.LAUNCHED_BY_COMPATION, false)) {
             LorieService.sendRunCommand(this);
         }
+    }
+
+    @Override
+    public void setTheme(int resId) {
+        // for some reason, calling setTheme() in onCreate() wasn't working.
+        super.setTheme(didRequestLaunchExternalDisplay() ?
+                R.style.FullScreen_ExternalDisplay : R.style.NoActionBar);
+    }
+
+    private boolean didRequestLaunchExternalDisplay() {
+        return getIntent().getBooleanExtra(REQUEST_LAUNCH_EXTERNAL_DISPLAY, false);
+    }
+
+    private void setFullScreenForExternalDisplay() {
+        getWindow().getDecorView().setSystemUiVisibility(
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_IMMERSIVE);
     }
 
     int orientation;

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -18,4 +18,11 @@
         <item name="android:fitsSystemWindows">true</item>
     </style>
 
+    <!-- For use w/ external displays to be able to use entire display surface area -->
+    <style name="FullScreen.ExternalDisplay" parent="@style/Theme.AppCompat.DayNight.NoActionBar">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+    </style>
 </resources>


### PR DESCRIPTION
This is only applicable for **Android 10+ devices that support HDMI output over USB** and have enabled the **Experimental desktop mode** developer option. (_Oreo technically supports external displays, but keyboard + mouse input isn't mapped properly, so wouldn't be very useful._)

If there is an external display connected, the `MainActivity` will be launched on that external display. It will also be displayed in fullscreen w/o any navigation / floating window controls, allowing to use entire display surface area.

<img width="822" src="https://user-images.githubusercontent.com/6166095/189546078-86d4100b-69fa-4413-8234-207bdad25829.png">

* To get full screen to show properly, the correct theme needs to be set at runtime (instead of in Manifest)

## My Setup
On my personal device, I have a tasker termux shortcut accessible from home screen that runs the commands from the README
```bash
export XDG_RUNTIME_DIR=${TMPDIR}
termux-x11 :1 &
env DISPLAY=:1 xfce4-session
```

Now, when I tap the shortcut the `MainActivity` will be launched on my external display if it is connected.

* Tested w/ OnePlus 8T - Android 11
