### PR TITLE
Allow audio playback capture for Android 10+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:hardwareAccelerated="true"
+        android:allowAudioPlaybackCapture="true"
         tools:ignore="GoogleAppIndexingWarning">
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
This allows screen recorders on Android 10 and above to capture the audio 