### PR TITLE
Dex touchpad fix: orientation, click, gesture, etc.

### DIFF
--- a/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -531,15 +531,8 @@ public class TouchInputHandler {
             if ((e2.getSource() & InputDevice.SOURCE_TOUCHPAD) == InputDevice.SOURCE_TOUCHPAD
                     && mInputStrategy instanceof InputStrategyInterface.TrackpadInputStrategy) {
                 float temp;
-                int transform = capturedPointerTransformation;
-                if (capturedPointerTransformation == CapturedPointerTransformation.AUTO) {
-                    for (Display display : mDisplayManager.getDisplays()) {
-                        if (display.getState() == Display.STATE_ON) {
-                            transform = display.getRotation() % 4;
-                            break;
-                        }
-                    }
-                }
+                int transform = capturedPointerTransformation == CapturedPointerTransformation.AUTO ?
+                        mDisplayManager.getDisplay(Display.DEFAULT_DISPLAY).getRotation() % 4 : capturedPointerTransformation;
                 switch (transform) {
                     case CapturedPointerTransformation.NONE:
                         break;

--- a/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -14,10 +14,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.PointF;
+import android.hardware.display.DisplayManager;
 import android.hardware.input.InputManager;
 import android.os.Handler;
 import android.os.Build;
 import android.util.DisplayMetrics;
+import android.view.Display;
 import android.view.GestureDetector;
 import android.view.InputDevice;
 import android.view.KeyEvent;
@@ -156,6 +158,7 @@ public class TouchInputHandler {
         mRenderData = renderData != null ? renderData :new RenderData();
         mInjector = injector;
         mActivity = activity;
+        mDisplayManager = (DisplayManager) mActivity.getSystemService(Context.DISPLAY_SERVICE);
 
         GestureListener listener = new GestureListener();
         mScroller = new GestureDetector(/*desktop*/ activity, listener, null, false);
@@ -365,7 +368,7 @@ public class TouchInputHandler {
     }
 
     public void setInputMode(@InputMode int inputMode) {
-        if (SamsungDexUtils.checkDeXEnabled(mContext)) {
+        if (SamsungDexUtils.checkDeXEnabled(mActivity)) {
             mInputStrategy = new InputStrategyInterface.TrackpadInputStrategy(mInjector);
             return;
         }

--- a/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -301,18 +301,15 @@ public class TouchInputHandler {
             mTapDetector.onTouchEvent(event);
             mSwipePinchDetector.onTouchEvent(event);
 
+            // For hardware touchpad in DeX (captured mode), handle physical click buttons
+            if ((event.getSource() & InputDevice.SOURCE_TOUCHPAD) == InputDevice.SOURCE_TOUCHPAD) {
+                currentBS = event.getButtonState();
+                for (int[] button: buttons)
+                    if (isMouseButtonChanged(button[0]))
+                        mInjector.sendMouseEvent(null, button[1], mouseButtonDown(button[0]), true);
+                savedBS = currentBS;
+            }
             switch (event.getActionMasked()) {
-                case MotionEvent.ACTION_BUTTON_PRESS:
-                case MotionEvent.ACTION_BUTTON_RELEASE:
-                    // For hardware touchpad in DeX (captured mode), handle physical click buttons
-                    if ((event.getSource() & InputDevice.SOURCE_TOUCHPAD) == InputDevice.SOURCE_TOUCHPAD) {
-                        currentBS = event.getButtonState();
-                        for (int[] button: buttons)
-                            if (isMouseButtonChanged(button[0]))
-                                mInjector.sendMouseEvent(null, button[1], mouseButtonDown(button[0]), true);
-                        savedBS = currentBS;
-                        break;
-                    }
                 case MotionEvent.ACTION_DOWN:
                     mSuppressCursorMovement = false;
                     mSwipeCompleted = false;

--- a/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -63,13 +63,15 @@ public class TouchInputHandler {
         int TOUCH = 3;
     }
 
-    @IntDef({CapturedPointerTransformation.NONE, CapturedPointerTransformation.CLOCKWISE, CapturedPointerTransformation.COUNTER_CLOCKWISE, CapturedPointerTransformation.UPSIDE_DOWN})
+    @IntDef({CapturedPointerTransformation.NONE, CapturedPointerTransformation.CLOCKWISE, CapturedPointerTransformation.UPSIDE_DOWN, CapturedPointerTransformation.COUNTER_CLOCKWISE, CapturedPointerTransformation.AUTO})
     @Retention(RetentionPolicy.SOURCE)
     public @interface CapturedPointerTransformation {
+        // values correspond to transformation needed given getRotation(), e.g. getRotation() = 1 requires counter-clockwise transformation
         int NONE = 0;
-        int CLOCKWISE = 1;
-        int COUNTER_CLOCKWISE = 2;
-        int UPSIDE_DOWN = 3;
+        int CLOCKWISE = 3;
+        int UPSIDE_DOWN = 2;
+        int COUNTER_CLOCKWISE = 1;
+        int AUTO = -1;
     }
 
     private final RenderData mRenderData;
@@ -128,8 +130,9 @@ public class TouchInputHandler {
      * is performing a drag operation.
      */
     private boolean mIsDragging;
+    private static DisplayManager mDisplayManager;
 
-    @CapturedPointerTransformation int capturedPointerTransformation = CapturedPointerTransformation.NONE;
+    @CapturedPointerTransformation static int capturedPointerTransformation = CapturedPointerTransformation.NONE;
 
     private TouchInputHandler(MainActivity activity, RenderData renderData,
                               final InputEventSender injector, boolean isTouchpad) {
@@ -252,9 +255,7 @@ public class TouchInputHandler {
 
         if (!isDexEvent(event) && (event.getToolType(event.getActionIndex()) == MotionEvent.TOOL_TYPE_MOUSE
                 || (event.getSource() & InputDevice.SOURCE_MOUSE) == InputDevice.SOURCE_MOUSE)
-                || (event.getSource() & InputDevice.SOURCE_MOUSE_RELATIVE) == InputDevice.SOURCE_MOUSE_RELATIVE
-                || (event.getPointerCount() == 1 && mTouchpadHandler == null
-                   && (event.getSource() & InputDevice.SOURCE_TOUCHPAD) == InputDevice.SOURCE_TOUCHPAD))
+                || (event.getSource() & InputDevice.SOURCE_MOUSE_RELATIVE) == InputDevice.SOURCE_MOUSE_RELATIVE)
             return mHMListener.onTouch(view, event);
 
         if (event.getToolType(event.getActionIndex()) == MotionEvent.TOOL_TYPE_FINGER) {
@@ -339,6 +340,10 @@ public class TouchInputHandler {
     }
 
     public void setInputMode(@InputMode int inputMode) {
+        if (SamsungDexUtils.checkDeXEnabled(mContext)) {
+            mInputStrategy = new InputStrategyInterface.TrackpadInputStrategy(mInjector);
+            return;
+        }
         if (inputMode == InputMode.TOUCH)
             mInputStrategy = new InputStrategyInterface.NullInputStrategy();
         else if (inputMode == InputMode.SIMULATED_TOUCH)
@@ -395,6 +400,9 @@ public class TouchInputHandler {
                 break;
             case "ud":
                 capturedPointerTransformation = CapturedPointerTransformation.UPSIDE_DOWN;
+                break;
+            case "at":
+                capturedPointerTransformation = CapturedPointerTransformation.AUTO;
                 break;
             default:
                 capturedPointerTransformation = CapturedPointerTransformation.NONE;
@@ -490,6 +498,30 @@ public class TouchInputHandler {
         public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
             int pointerCount = e2.getPointerCount();
 
+            // Automatic (for touchpad) mode is needed because touchpads ignore screen orientation and report physical X and Y
+            if ((e2.getSource() & InputDevice.SOURCE_TOUCHPAD) == InputDevice.SOURCE_TOUCHPAD
+                    && mInputStrategy instanceof InputStrategyInterface.TrackpadInputStrategy) {
+                float temp;
+                int transform = capturedPointerTransformation;
+                if (capturedPointerTransformation == CapturedPointerTransformation.AUTO) {
+                    for (Display display : mDisplayManager.getDisplays()) {
+                        if (display.getState() == Display.STATE_ON) {
+                            transform = display.getRotation() % 4;
+                            break;
+                        }
+                    }
+                }
+                switch (transform) {
+                    case CapturedPointerTransformation.NONE:
+                        break;
+                    case CapturedPointerTransformation.CLOCKWISE:
+                        temp = distanceX; distanceX = -distanceY; distanceY = temp; break;
+                    case CapturedPointerTransformation.COUNTER_CLOCKWISE:
+                        temp = distanceX; distanceX = distanceY; distanceY = -temp; break;
+                    case CapturedPointerTransformation.UPSIDE_DOWN:
+                        distanceX = -distanceX; distanceY = -distanceY; break;
+                }
+            }
             if (pointerCount >= 3 && !mSwipeCompleted) {
                 // Note that distance values are reversed. For example, dragging a finger in the
                 // direction of increasing Y coordinate (downwards) results in distanceY being

--- a/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -524,6 +524,7 @@ public class TouchInputHandler {
         public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
             int pointerCount = e2.getPointerCount();
 
+            // For captured touchpad pointer:
             // Automatic (for touchpad) mode is needed because touchpads ignore screen orientation and report physical X and Y
             if ((e2.getSource() & InputDevice.SOURCE_TOUCHPAD) == InputDevice.SOURCE_TOUCHPAD
                     && mInputStrategy instanceof InputStrategyInterface.TrackpadInputStrategy) {
@@ -547,7 +548,11 @@ public class TouchInputHandler {
                     case CapturedPointerTransformation.UPSIDE_DOWN:
                         distanceX = -distanceX; distanceY = -distanceY; break;
                 }
+                distanceX *= mInjector.capturedPointerSpeedFactor;
+                distanceY *= mInjector.capturedPointerSpeedFactor;
             }
+
+
             if (pointerCount >= 3 && !mSwipeCompleted) {
                 // Note that distance values are reversed. For example, dragging a finger in the
                 // direction of increasing Y coordinate (downwards) results in distanceY being
@@ -574,9 +579,10 @@ public class TouchInputHandler {
 
             if (mInputStrategy instanceof InputStrategyInterface.TrackpadInputStrategy) {
                 if (mInjector.scaleTouchpad) {
-                    distanceX *= mRenderData.scale.x;
+                    distanceX *= mRenderData.scale.x ;
                     distanceY *= mRenderData.scale.y;
                 }
+
                 moveCursorByOffset(distanceX, distanceY);
             }
             if (!(mInputStrategy instanceof InputStrategyInterface.TrackpadInputStrategy) && mIsDragging) {

--- a/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -133,6 +133,23 @@ public class TouchInputHandler {
      */
     private boolean mIsDragging;
     private static DisplayManager mDisplayManager;
+    private static int mDisplayRotation;
+    private static final DisplayManager.DisplayListener mDisplayListener = new DisplayManager.DisplayListener() {
+        @Override
+        public void onDisplayAdded(int displayId) {
+            mDisplayRotation = mDisplayManager.getDisplay(Display.DEFAULT_DISPLAY).getRotation() % 4;
+        }
+
+        @Override
+        public void onDisplayRemoved(int displayId) {
+            mDisplayRotation = mDisplayManager.getDisplay(Display.DEFAULT_DISPLAY).getRotation() % 4;
+        }
+
+        @Override
+        public void onDisplayChanged(int displayId) {
+            mDisplayRotation = mDisplayManager.getDisplay(Display.DEFAULT_DISPLAY).getRotation() % 4;
+        }
+    };
 
     @CapturedPointerTransformation static int capturedPointerTransformation = CapturedPointerTransformation.NONE;
     private final int[][] buttons = {
@@ -158,7 +175,11 @@ public class TouchInputHandler {
         mRenderData = renderData != null ? renderData :new RenderData();
         mInjector = injector;
         mActivity = activity;
-        mDisplayManager = (DisplayManager) mActivity.getSystemService(Context.DISPLAY_SERVICE);
+        if (mDisplayManager == null) {
+            mDisplayManager = (DisplayManager) mActivity.getSystemService(Context.DISPLAY_SERVICE);
+            mDisplayRotation = mDisplayManager.getDisplay(Display.DEFAULT_DISPLAY).getRotation() % 4;
+            mDisplayManager.registerDisplayListener(mDisplayListener, null);
+        }
 
         GestureListener listener = new GestureListener();
         mScroller = new GestureDetector(/*desktop*/ activity, listener, null, false);
@@ -529,7 +550,7 @@ public class TouchInputHandler {
                     && mInputStrategy instanceof InputStrategyInterface.TrackpadInputStrategy) {
                 float temp;
                 int transform = capturedPointerTransformation == CapturedPointerTransformation.AUTO ?
-                        mDisplayManager.getDisplay(Display.DEFAULT_DISPLAY).getRotation() % 4 : capturedPointerTransformation;
+                        mDisplayRotation : capturedPointerTransformation;
                 switch (transform) {
                     case CapturedPointerTransformation.NONE:
                         break;

--- a/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -63,15 +63,15 @@ public class TouchInputHandler {
         int TOUCH = 3;
     }
 
-    @IntDef({CapturedPointerTransformation.NONE, CapturedPointerTransformation.CLOCKWISE, CapturedPointerTransformation.UPSIDE_DOWN, CapturedPointerTransformation.COUNTER_CLOCKWISE, CapturedPointerTransformation.AUTO})
+    @IntDef({CapturedPointerTransformation.AUTO, CapturedPointerTransformation.NONE, CapturedPointerTransformation.COUNTER_CLOCKWISE, CapturedPointerTransformation.UPSIDE_DOWN, CapturedPointerTransformation.CLOCKWISE})
     @Retention(RetentionPolicy.SOURCE)
     public @interface CapturedPointerTransformation {
         // values correspond to transformation needed given getRotation(), e.g. getRotation() = 1 requires counter-clockwise transformation
-        int NONE = 0;
-        int CLOCKWISE = 3;
-        int UPSIDE_DOWN = 2;
-        int COUNTER_CLOCKWISE = 1;
         int AUTO = -1;
+        int NONE = 0;
+        int COUNTER_CLOCKWISE = 1;
+        int UPSIDE_DOWN = 2;
+        int CLOCKWISE = 3;
     }
 
     private final RenderData mRenderData;
@@ -295,7 +295,6 @@ public class TouchInputHandler {
             mScroller.onTouchEvent(event);
             mTapDetector.onTouchEvent(event);
             mSwipePinchDetector.onTouchEvent(event);
-
 
             switch (event.getActionMasked()) {
                 case MotionEvent.ACTION_BUTTON_PRESS:
@@ -579,10 +578,9 @@ public class TouchInputHandler {
 
             if (mInputStrategy instanceof InputStrategyInterface.TrackpadInputStrategy) {
                 if (mInjector.scaleTouchpad) {
-                    distanceX *= mRenderData.scale.x ;
+                    distanceX *= mRenderData.scale.x;
                     distanceY *= mRenderData.scale.y;
                 }
-
                 moveCursorByOffset(distanceX, distanceY);
             }
             if (!(mInputStrategy instanceof InputStrategyInterface.TrackpadInputStrategy) && mIsDragging) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -15,12 +15,14 @@
         <item>Clockwise</item>
         <item>Counter clockwise</item>
         <item>Upside down</item>
+        <item>Automatic (for touchpad)</item>
     </string-array>
     <string-array name="transformCapturedPointerValues">
         <item>no</item>
         <item>c</item>
         <item>cc</item>
         <item>ud</item>
+        <item>at</item>
     </string-array>
     <string-array name="displayResolutionVariants">
         <item>native</item>


### PR DESCRIPTION
In short, it should fix #419. The suggested changes should have no impact on existing functionality. If you need to review the code changes and features added, I hope below explanation helps and won't be too long. 

## Root Causes of #419  
* Unlike touchscreen, the tocuchpad reports coordinates in its own (physical) orientation, does not flip along with display rotation.  
* Also, the comment at [line 185](https://github.com/termux/termux-x11/blob/5489f7c8726855cd55729660c2867139aa2a5a74/app/src/main/java/com/termux/x11/input/TouchInputHandler.java#L185) "Regular touchpads and Dex touchpad ... should be handled as touchscreens with **trackpad** mode" is not implemented as expected. Indeed, `mTouchpadHandler.handleTouchEvent()` will handle pointer inputs as hardware mouse, calling `mHMListener.onTouch` because of the "if condition" (`|| (event.getPointerCount() == 1 && mTouchpadHandler == null && (event.getSource() & InputDevice.SOURCE_TOUCHPAD) == InputDevice.SOURCE_TOUCHPAD)`) being positive. 

## My solution
* Remove the "if condition" so that touchpad event can invoke `TrackpadInputStrategy`. Note that we could not simply create another variable to be invoked because the code logics test `mInputStrategy` at multiple places. I found it easiest to just override `mInputStrategy` in DeX (`SamsungDexUtils.checkDeXEnabled(mContext)`). This makes sense  because (1) finger input in DeX can only be touchpad not touchscreen, and (2) mouse input handler in DeX is also overrided. 
* The flipped axis issue is tackled by introducing another option for captured pointer transformation, namely "Automatic (for touchpad)". Under this option, the rotation of display ~ID 1 (primary display I believe)~ will be checked and motion input will be handled accordingly. Hopefully this could handle both Pad and DeX touchpad issue. 
* The 3-finger down gesture to "toggle EK bar" is change to  "release pointer capture" under DeX mode. This is because (1) EK bar is useless and cannot be pressed in captured pointer mode, and (2) if user enters DeX using solely soft touchpad and soft keyboard, there should be a way to exit the capture mode and the more-than-2-finger gesture is just right play that role (3-finger as shortcut to release capture plus minimize window, 4-finger to only release capture). At the end, the current way for soft touchpad & soft keyboard under DeX to use EK bar is perhaps to first release pointer capture and use volume key to toggle EK bar.  