### PR TITLE
Fix touchpad transform having no effect

### DIFF
--- a/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -317,6 +317,9 @@ public class TouchInputHandler {
 
         keyIntercepting = !mInjector.pauseKeyInterceptingWithEsc || mActivity.getLorieView().hasPointerCapture();
         SamsungDexUtils.dexMetaKeyCapture(mActivity, mInjector.dexMetaKeyCapture && keyIntercepting);
+
+        if(mTouchpadHandler != null)
+            mTouchpadHandler.reloadPreferences(p);
     }
 
     public boolean shouldInterceptKeys() {


### PR DESCRIPTION
The Touchpad transform currently has no effect because the TouchInputHandler mTouchpadHandler does not receive updates to the config. I looked through the uses of it and found out that although one could apply a far simpler patch, the mTouchpadHandler actually has no extra functionality and can be removed without any change in behavior. This both reduces code complexity and fixes the touchpad transform. 

If this solution is unwanted, I can move to the smaller patch instead - though I personally don't see any metric where that solution would be better unless mTouchpadHandler has some very obscure function that I wasn't able to find or discover during preliminary testing.