### PR TITLE
OpenXR - BT/OTG support and hardcode native resolution

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
 
     <uses-feature android:name="android.hardware.vr.headtracking" android:required="false" />
     <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
+    <uses-feature android:name="oculus.software.handtracking" android:required="false" />
     <uses-feature android:name="oculus.software.overlay_keyboard" android:required="false" />
 
     <application

--- a/app/src/main/java/com/termux/x11/LorieView.java
+++ b/app/src/main/java/com/termux/x11/LorieView.java
@@ -140,7 +140,7 @@ public class LorieView extends SurfaceView implements InputStub {
         int height = getMeasuredHeight();
         if (XrActivity.isEnabled()) {
             width = 1024;
-            height = 1024;
+            height = 768;
         }
         int w = width;
         int h = height;

--- a/app/src/main/java/com/termux/x11/LorieView.java
+++ b/app/src/main/java/com/termux/x11/LorieView.java
@@ -138,6 +138,10 @@ public class LorieView extends SurfaceView implements InputStub {
         Prefs prefs = MainActivity.getPrefs();
         int width = getMeasuredWidth();
         int height = getMeasuredHeight();
+        if (XrActivity.isEnabled()) {
+            width = 1024;
+            height = 1024;
+        }
         int w = width;
         int h = height;
         switch(prefs.displayResolutionMode.get()) {
@@ -180,8 +184,11 @@ public class LorieView extends SurfaceView implements InputStub {
         if (prefs.displayStretch.get()
               || "native".equals(prefs.displayResolutionMode.get())
               || "scaled".equals(prefs.displayResolutionMode.get())) {
-            getHolder().setSizeFromLayout();
-            return;
+
+            if (!XrActivity.isEnabled()) {
+                getHolder().setSizeFromLayout();
+                return;
+            }
         }
 
         getDimensionsFromSettings();

--- a/app/src/main/java/com/termux/x11/XrActivity.java
+++ b/app/src/main/java/com/termux/x11/XrActivity.java
@@ -49,7 +49,6 @@ public class XrActivity extends MainActivity implements GLSurfaceView.Renderer {
 
     private boolean isImmersive = false;
     private boolean isSBS = false;
-    private boolean hasFocus = false;
     private boolean keyboardDisabled;
     private long lastEnter;
     private final float[] lastAxes = new float[ControllerAxis.values().length];
@@ -189,7 +188,6 @@ public class XrActivity extends MainActivity implements GLSurfaceView.Renderer {
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
-        this.hasFocus = hasFocus;
         if (hasFocus) {
             keyboardDisabled = true;
             new Handler().postDelayed(() -> keyboardDisabled = false, 250);
@@ -204,7 +202,7 @@ public class XrActivity extends MainActivity implements GLSurfaceView.Renderer {
         }
 
         // Bluetooth/OTG keyboards work properly with the standard flow
-        if (hasFocus) {
+        if (hasWindowFocus()) {
             return super.dispatchKeyEvent(event);
         }
 


### PR DESCRIPTION
This addresses XR issues mentioned in https://github.com/termux/termux-x11/issues/665.

* Support XR mode without controllers (patch of `AndroidManifest.xml`)
* Set resolution for "native" lower (patch of `LorieView.java`)
* Support for BT/OTG keyboard (patch of `XrActivity.java`)