### PR TITLE
Unbuffer `MotionEvent` objects for touch events to avoid ignoring points and reduce latency

### DIFF
--- a/app/src/main/java/com/termux/x11/MainActivity.java
+++ b/app/src/main/java/com/termux/x11/MainActivity.java
@@ -177,7 +177,14 @@ public class MainActivity extends AppCompatActivity implements View.OnApplyWindo
             return result;
         };
 
-        lorieParent.setOnTouchListener((v, e) -> mInputHandler.handleTouchEvent(lorieParent, lorieView, e));
+        lorieParent.setOnTouchListener((v, e) -> {
+            // Avoid batched MotionEvent objects and reduce potential latency.
+            // For reference: https://developer.android.com/develop/ui/views/touch-and-input/stylus-input/advanced-stylus-features#rendering.
+            if (e.getAction() == MotionEvent.ACTION_DOWN)
+                lorieParent.requestUnbufferedDispatch(e);
+
+            return mInputHandler.handleTouchEvent(lorieParent, lorieView, e);
+        });
         lorieParent.setOnHoverListener((v, e) -> mInputHandler.handleTouchEvent(lorieParent, lorieView, e));
         lorieParent.setOnGenericMotionListener((v, e) -> mInputHandler.handleTouchEvent(lorieParent, lorieView, e));
         lorieView.setOnCapturedPointerListener((v, e) -> mInputHandler.handleTouchEvent(lorieView, lorieView, e));


### PR DESCRIPTION
It fixes the problem that, when the touchscreen/stylus sampling rate is higher than the screen refresh rate, multiple points from the touchscreen/stylus are batched into a single `MotionEvent` object with extra latency, and all points of this object except the most current one are ignored.

For reference:
- https://developer.android.com/develop/ui/views/touch-and-input/stylus-input/advanced-stylus-features#rendering
- https://developer.android.com/reference/android/view/MotionEvent#batching

In the following samples, strokes were drawn with stylus (whose sampling rate is 240Hz), and the FPS is 60Hz. Red points and blue strokes were presented by the "show taps" option in developer options, and the green strokes were presented by xournal++ (`xournalpp` package in termux x11 repo). Before the patch was applied, 3 of every 4 points were ignored by termux-x11.

| before the patch | after the patch |
| --- | --- |
|![before](https://github.com/user-attachments/assets/60511ded-0167-4a12-8fb5-078aec4ed5a8)| ![after](https://github.com/user-attachments/assets/3e54235b-dae6-4d89-9811-47173a9932e3)|
|![before (without  show taps )](https://github.com/user-attachments/assets/a31855f2-3ddb-41f9-bdf5-0f28add550a7)| ![after (without  show taps )](https://github.com/user-attachments/assets/53a1dd12-6d74-479e-a3e1-1e2d364346e5)|


