### PR TITLE
change Xserver process name to termux-x11

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,28 +73,33 @@ For some reason some devices show screen with swapped colours, in this case you 
 
 ## Using with proot environment
 If you plan to use the program with proot, keep in mind that you need to launch proot/proot-distro with the --shared-tmp option. 
+
 If passing this option is not possible, set the TMPDIR environment variable to point to the directory that corresponds to /tmp in the target container.
+
 If you are using proot-distro you should know that it is possible to start `termux-x11` command from inside proot container.
 
 ## Using with chroot environment
-If you plan to use the program with chroot or unshare, you must to run it as root and set the TMPDIR environment variable to point to the directory that corresponds to /tmp in the target container. 
+If you plan to use the program with chroot or unshare, you must to run it as root and set the TMPDIR environment variable to point to the directory that corresponds to /tmp in the target container.
+
 This directory must be accessible from the shell from which you launch termux-x11, i.e. it must be in the same SELinux context, same mount namespace, and so on.
+
 Also you must set `XKB_CONFIG_ROOT` environment variable pointing to container's `/usr/share/X11/xkb` directory, otherwise you will have `xkbcomp`-related errors.
+
 You can get loader for nightly build from an artifact of [last successful build](https://github.com/termux/termux-x11/actions/workflows/debug_build.yml)
+
 Do not forget to disable SELinux
 ```
 setenforce 0
 export TMPDIR=/path/to/chroot/container/tmp
 export CLASSPATH=$(/system/bin/pm path com.termux.x11 | cut -d: -f2)
-/system/bin/app_process / com.termux.x11.CmdEntryPoint :0
+/system/bin/app_process / --nice-name=termux-x11 com.termux.x11.CmdEntryPoint :0
 ```
 
 ### Force stopping X server (running in termux background, not an activity)
 
-termux-x11's X server runs in process with name "app_process", not "termux-x11". But you can kill it by searching "com.termux.x11" in commandline.
-So killing it will look like
+termux-x11's X server runs in process with name "termux-x11". You can kill it by
 ```
-pkill -f com.termux.x11
+pkill termux-x11
 ```
 
 ### Closing Android activity (running in foreground, not X server)

--- a/termux-x11
+++ b/termux-x11
@@ -4,4 +4,4 @@
 [ -z "${CLASSPATH+x}" ] || export XSTARTUP_CLASSPATH="$CLASSPATH"
 export CLASSPATH=/data/data/com.termux/files/usr/libexec/termux-x11/loader.apk
 unset LD_LIBRARY_PATH LD_PRELOAD
-exec /system/bin/app_process -Xnoimage-dex2oat / com.termux.x11.Loader "$@"
+exec /system/bin/app_process -Xnoimage-dex2oat / --nice-name="termux-x11 com.termux.x11 $*" com.termux.x11.Loader "$@"


### PR DESCRIPTION
using app_process option `--nice-name=termux-x11` to set its process name  to termux-x11\
so that users can understand the process better and easier to kill the process manually

but this will break the current pattern where users kill process using `pkill -f com.termux.x11`

before
```
~ $ ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
u0_a287   3584  2.5  2.5 8907428 182396 ?      S<l   1970   0:26 com.termux
u0_a287   3673  0.0  0.0 2219460 3732 pts/0    S<s   1970   0:00 /data/data/com.termux/files/usr/bin/bash -l
u0_a287   8889  0.0  0.0 2190788 4440 pts/1    S<s   1970   0:00 /data/data/com.termux/files/usr/bin/bash -l
u0_a287  12646  9.4  2.1 7892644 154636 pts/0  S<l+  1970   0:01 /system/bin/app_process -Xnoimage-dex2oat / com.termu
u0_a287  12771  1.0  0.0 2176452 3052 pts/1    R<+   1970   0:00 ps aux
```

after
```
~ $ ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
u0_a287   3584  2.8  2.3 8924684 171152 ?      S<l   1970   0:31 com.termux
u0_a287   3673  0.0  0.0 2219460 3732 pts/0    S<s   1970   0:00 /data/data/com.termux/files/usr/bin/bash -l
u0_a287   8889  0.0  0.0 2190788 4440 pts/1    S<s   1970   0:00 /data/data/com.termux/files/usr/bin/bash -l
u0_a287  13124 11.5  2.1 7599780 154116 pts/0  S<l+  1970   0:00 termux-x11
u0_a287  13167  1.0  0.0 2170308 3128 pts/1    R<+   1970   0:00 ps aux
```