### PR TITLE
chore: remove libarchive-tools from workflow.

### DIFF
--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -19,13 +19,11 @@ jobs:
     name: "Build"
     runs-on: ubuntu-latest
     steps:
-    - name: Install dependencies
-      run: |
-        sudo apt update && sudo apt install -y libarchive-tools
     - name: Clone repository
       uses: actions/checkout@v4
       with:
         submodules: recursive
+        fetch-depth: 1
     - name: Validation
       uses: gradle/actions/wrapper-validation@v4
       

--- a/build_termux_package
+++ b/build_termux_package
@@ -30,6 +30,7 @@ mkdir -p $PREFIX/libexec/termux-x11
 mkdir -p "$(dirname $DEB_PACKAGE_PATH)"
 
 cp termux-x11 $PREFIX/bin/
+cp termux-x11-preference $PREFIX/bin/
 cp shell-loader/build/outputs/apk/debug/shell-loader-debug.apk \
 	$PREFIX/libexec/termux-x11/loader.apk
 
@@ -46,7 +47,7 @@ EOF
 
 cat <<EOF > $CONTROL_DIR/postinst
 #!/data/data/com.termux/files/usr/bin/sh
-chmod -w /data/data/com.termux/files/usr/libexec/termux-x11/loader.apk
+chmod 400 /data/data/com.termux/files/usr/libexec/termux-x11/loader.apk
 EOF
 
 mkdir -p $PACKAGE_DIR
@@ -62,6 +63,7 @@ ar -rsc $DEB_PACKAGE_PATH \
 ### Deploy pacman package
 
 BUILD_DATE=$(date +%s)
+TERMUX_PKG_INSTALLSIZE="$(du -bs $DATA_DIR | cut -f 1)"
 
 {
   echo "pkgname = $TERMUX_PKG_NAME"
@@ -71,8 +73,12 @@ BUILD_DATE=$(date +%s)
   echo "url = $TERMUX_PKG_HOMEPAGE"
   echo "builddate = $BUILD_DATE"
   echo "packager = $TERMUX_PKG_MAINTAINER"
+  echo "size = $TERMUX_PKG_INSTALLSIZE"
   echo "arch = any"
-  echo "license = TERMUX_PKG_LICENSE"
+  echo "license = GPL-3.0"
+  echo "replaces = termux-x11"
+  echo "conflict = termux-x11"
+  echo "provides = termux-x11"
   tr ',' '\n' <<< "$TERMUX_PKG_DEPENDS" | sed 's|(||g; s|)||g; s| ||g; s|>>|>|g; s|<<|<|g' | awk '{ printf "depend = " $1; if ( ($1 ~ /</ || $1 ~ />/ || $1 ~ /=/) && $1 !~ /-/ ) printf "-0"; printf "\n" }' | sed 's/|.*//'
 } > $DATA_DIR/.PKGINFO
 
@@ -88,7 +94,10 @@ BUILD_DATE=$(date +%s)
 
 {
   echo "post_install() {"
-  echo "    chmod -w /data/data/com.termux/files/usr/libexec/termux-x11/loader.apk"
+  echo "    chmod 400 /data/data/com.termux/files/usr/libexec/termux-x11/loader.apk"
+  echo "}"
+  echo "post_upgrade() {"
+  echo "    post_install"
   echo "}"
 } > $DATA_DIR/.INSTALL
 
@@ -96,9 +105,42 @@ PACMAN_PACKAGE_PATH=`realpath $PACMAN_PACKAGE_PATH`
 
 cd $DATA_DIR
 shopt -s dotglob globstar
-printf '%s\0' data/**/* .BUILDINFO .PKGINFO | bsdtar -cnf - --format=mtree \
-  --options='!all,use-set,type,uid,gid,mode,time,size,md5,sha256,link' \
-  --null --files-from - | gzip -c -f -n > .MTREE
-printf '%s\0' data/**/* .BUILDINFO .PKGINFO .MTREE | bsdtar --no-fflags -cnf - --null --files-from - | xz > "$PACMAN_PACKAGE_PATH"
+mapfile -d '' FILES < <(printf '%s\0' .BUILDINFO .INSTALL .PKGINFO data/**/*)
+printf '%s\n' ${FILES[@]}
 shopt -u dotglob globstar
-cd -
+
+# Bsdtar is missing in Github CI image and installing it takes a while
+# so effectively this code replaces
+# printf '%s\0' data/**/* .BUILDINFO .INSTALL .PKGINFO | bsdtar -cnf - --format=mtree --options='!all,use-set,type,uid,gid,mode,time,size,md5,sha256,link' --null --files-from - | gzip -c -f -n > .MTREE
+# printf '%s\0' data/**/* .BUILDINFO .INSTALL .PKGINFO .MTREE | bsdtar --no-fflags -cnf - --null --files-from - | xz > "$PACMAN_PACKAGE_PATH"
+
+{
+_mode="664"
+echo "#mtree"
+echo "/set type=file uid=1000 gid=1000 mode=$_mode"
+for path in "${FILES[@]}"; do
+  # Skip non-existing paths (due to globs resolving to themselves)
+  [ -e "$path" ] || continue
+
+  if [ -d "$path" ]; then
+    mode="$(stat -c '%a' "$path")"
+    mtime="$(stat -c '%Y' "$path").$(stat -c '%y' "$path" | cut -d'.' -f2 | cut -d' ' -f1)"
+    if [ "$mode" != "$_mode" ]; then
+        echo "/set mode=$mode"
+        _mode="$mode"
+    fi
+    printf '%q time=%s type=dir\n' "$path" "$mtime"
+
+  elif [ -f "$path" ]; then
+    mode="$(stat -c '%a' "$path")"
+    mtime="$(stat -c '%Y' "$path").$(stat -c '%y' "$path" | cut -d'.' -f2 | cut -d' ' -f1)"
+    size="$(stat -c '%s' "$path")"
+    md5="$(md5sum "$path" | cut -d' ' -f1)"
+    sha256="$(sha256sum "$path" | cut -d' ' -f1)"
+    printf '%q time=%s%s size=%s md5digest=%s sha256digest=%s%s\n' \
+      "$path" "$mtime" "$([ "$mode" != "$_mode" ] && echo " mode=$mode")" "$size" "$md5" "$sha256"
+  fi
+done
+} | gzip > .MTREE
+
+printf '%s\0' "${FILES[@]}" ".MTREE" | tar --null --no-recursion --hard-dereference --files-from=- -cf - | xz > "$PACMAN_PACKAGE_PATH"


### PR DESCRIPTION
Updating apt repositories and installing libarchive-tools takes some time. We can avoid wasting this time and generate pacman package without it.

@Maxython @robertkirkman I will be appreciated for review and probably on-device test.