### PR TITLE
fix: reenable abstract sockets and prevent socket leaking to xstartup session

### DIFF
--- a/app/src/main/cpp/patches/Xtrans.patch
+++ b/app/src/main/cpp/patches/Xtrans.patch
@@ -2,17 +2,6 @@ diff --git a/Xtranssock.c b/Xtranssock.c
 index b06579c..bb5238b 100644
 --- a/Xtranssock.c
 +++ b/Xtranssock.c
-@@ -141,10 +141,6 @@
- /* others don't need this */
- #define SocketInitOnce() /**/
- 
--#ifdef __linux__
--#define HAVE_ABSTRACT_SOCKETS
--#endif
--
- #define MIN_BACKLOG 128
- #ifdef SOMAXCONN
- #if SOMAXCONN > MIN_BACKLOG
 @@ -200,20 +196,28 @@ static int TRANS(SocketINETClose) (XtransConnInfo ciptr);
  
  

--- a/app/src/main/cpp/patches/xserver.patch
+++ b/app/src/main/cpp/patches/xserver.patch
@@ -349,3 +349,13 @@ index f9b7b06d9..f4b2aeddc 100644
      if (!IsKeyboardDevice(pDev))
          return;
  
+
++++ ./os/connection.c
+@@ -281,6 +281,7 @@ CreateWellKnownSockets(void)
+         int fd = _XSERVTransGetConnectionNumber(ListenTransConns[i]);
+
+         ListenTransFds[i] = fd;
++        _XSERVTransSetOption(ListenTransConns[i], TRANS_CLOSEONEXEC, 0);
+         SetNotifyFd(fd, EstablishNewConnections, X_NOTIFY_READ, NULL);
+
+         if (!_XSERVTransIsLocal(ListenTransConns[i]))


### PR DESCRIPTION
Closes https://github.com/termux/termux-packages/pull/24216