### PR TITLE
Fix: Set XKB_CONFIG_ROOT in launch script to resolve keymap warnings

### DIFF
--- a/termux-x11
+++ b/termux-x11
@@ -1,4 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/sh
+# Set the correct XKB configuration root to fix keyboard mapping errors
+export XKB_CONFIG_ROOT=/data/data/com.termux/files/usr/share/X11/xkb
+
 [ -z "${LD_LIBRARY_PATH+x}" ] || export XSTARTUP_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
 [ -z "${LD_PRELOAD+x}" ] || export XSTARTUP_LD_PRELOAD="$LD_PRELOAD"
 [ -z "${CLASSPATH+x}" ] || export XSTARTUP_CLASSPATH="$CLASSPATH"


### PR DESCRIPTION
This PR fixes the `xkbcomp` warnings on startup by setting the `XKB_CONFIG_ROOT` environment variable in the main launch script. 

This resolves the issue described in #923.