### PR TITLE
DRI3: advertise DRM_FORMAT_MOD_LINEAR to fix Vulkan tiling corruption

### DIFF
--- a/app/src/main/cpp/lorie/InitOutput.c
+++ b/app/src/main/cpp/lorie/InitOutput.c
@@ -985,14 +985,16 @@ static PixmapPtr loriePixmapFromFds(ScreenPtr screen, CARD8 num_fds, const int *
 }
 
 static int lorieGetFormats(__unused ScreenPtr screen, CARD32 *num_formats, CARD32 **formats) {
-    *num_formats = 0;
-    *formats = NULL;
+    static CARD32 format = DRM_FORMAT_ARGB8888;
+    *num_formats = 1;
+    *formats = &format;
     return TRUE;
 }
 
 static int lorieGetModifiers(__unused ScreenPtr screen, __unused uint32_t format, uint32_t *num_modifiers, uint64_t **modifiers) {
-    *num_modifiers = 0;
-    *modifiers = NULL;
+    static uint64_t modifier = 0; /* DRM_FORMAT_MOD_LINEAR */
+    *num_modifiers = 1;
+    *modifiers = &modifier;
     return TRUE;
 }
 


### PR DESCRIPTION
## Summary

- `lorieGetFormats()` and `lorieGetModifiers()` return empty lists, telling Vulkan clients (Mesa WSI) that the X server doesn't support DRI3 modifier negotiation
- Without modifiers, Mesa falls back to legacy scanout and the GPU driver picks optimal tiling (e.g. X-tiling on Intel) — but Xlorie reads shared DMA-BUFs as linear
- This causes **visible corruption (horizontal stripes)** in all Vulkan applications (Wine+DXVK, vkcube, etc.)
- The only current workaround is `MESA_VK_WSI_DEBUG=linear`, which forces ALL images linear at **5-15% GPU performance cost**

## Fix

Advertise `DRM_FORMAT_MOD_LINEAR` (0) as the only supported modifier and `DRM_FORMAT_ARGB8888` as the supported format. This tells Mesa to create linear-tiled buffers for DRI3 sharing, matching what Xlorie expects.

## Testing

Tested on Intel Iris Xe (Alder Lake), Android x86_64 (LineageOS 21), Mesa 25.0.7:
- **Before**: vkcube shows horizontal stripe corruption without `MESA_VK_WSI_DEBUG=linear`
- **After**: vkcube renders cleanly without the env var
- Wine+DXVK (Steam Big Picture) also works correctly

## Files changed

- `app/src/main/cpp/lorie/InitOutput.c` — `lorieGetFormats()` and `lorieGetModifiers()` now return supported format/modifier instead of empty lists