### PR TITLE
feat(displaylink): implement native DisplayLink USB display sink

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -17,6 +17,22 @@
     public static void main(java.lang.String[]);
 }
 
+# Keep DisplayLink bridge and all JNI-reflected classes/members.
+-keep class com.termux.x11.displaylink.DisplayLinkBridge {
+    public static boolean pushFrame(java.nio.ByteBuffer, int, int, int);
+    public static com.termux.x11.displaylink.DisplayLinkBridge getInstance();
+    public void start(android.content.Context);
+    public void stop();
+    public void onDisplayConnected(long);
+    public void onDisplayDisconnected(long);
+    public void onMonitorInfo(long, com.displaylink.manager.display.MonitorInfo);
+}
+
+-keep class com.displaylink.manager.NativeDriver { *; }
+-keep class com.displaylink.manager.NativeDriverListener { *; }
+-keep class com.displaylink.manager.display.DisplayMode { *; }
+-keep class com.displaylink.manager.display.MonitorInfo { *; }
+
 # Keep Preference subclasses' onSetInitialValue for reflective calls
 -keepclassmembers class * extends android.preference.Preference {
     void onSetInitialValue(boolean, java.lang.Object);

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-feature android:name="android.hardware.usb.host" />
 
     <application
         android:allowBackup="false"
@@ -69,8 +70,20 @@
                 <action android:name="com.termux.x11.CHANGE_PREFERENCE" />
             </intent-filter>
         </receiver>
+
+        <receiver
+            android:name=".displaylink.DisplayLinkDebugReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.termux.x11.displaylink.START" />
+                <action android:name="com.termux.x11.displaylink.STOP" />
+                <action android:name="com.termux.x11.displaylink.MARK" />
+            </intent-filter>
+        </receiver>
     </application>
     <queries>
         <package android:name="com.termux" />
+        <package android:name="com.displaylink.presenter" />
     </queries>
 </manifest>

--- a/app/src/main/cpp/lorie/InitOutput.c
+++ b/app/src/main/cpp/lorie/InitOutput.c
@@ -448,6 +448,40 @@ static Bool lorieRedraw(__unused ClientPtr pClient, __unused void *closure) {
     return TRUE;
 }
 
+static Bool lorieForceRenderWork(__unused ClientPtr pClient, __unused void *closure) {
+    PixmapPtr root;
+    BoxRec box;
+    RegionRec region;
+
+    if (!pvfb->state || !pScreenPtr || !pScreenPtr->root) {
+        return TRUE;
+    }
+
+    root = pScreenPtr->GetWindowPixmap(pScreenPtr->root);
+    if (!root) {
+        return TRUE;
+    }
+
+    box = (BoxRec) { 0, 0, (short) root->drawable.width, (short) root->drawable.height };
+    log(INFO, "DisplayLink force render work queued for %dx%d", root->drawable.width, root->drawable.height);
+    RegionInit(&region, &box, 1);
+    DamageDamageRegion(&root->drawable, &region);
+    RegionUninit(&region);
+    pvfb->state->drawRequested = TRUE;
+    pthread_cond_signal(&pvfb->state->cond);
+    return TRUE;
+}
+
+void lorieRequestRender(void) {
+    if (!pvfb->state || !pScreenPtr) {
+        return;
+    }
+
+    log(INFO, "DisplayLink force render requested");
+    QueueWorkProc(lorieForceRenderWork, NULL, NULL);
+    lorieWakeServer();
+}
+
 static CARD32 lorieFramecounter(unused OsTimerPtr timer, unused CARD32 time, unused void *arg) {
     if (pvfb->state->renderedFrames)
         log(INFO, "%d frames in 5.0 seconds = %.1f FPS",
@@ -690,7 +724,7 @@ void lorieConfigureNotify(int width, int height, int framerate, size_t name_size
         CARD32 mmWidth, mmHeight;
         RRModePtr mode = lorieCvt(width, height, framerate);
         mmWidth = ((double) (mode->mode.width)) * 25.4 / monitorResolution;
-        mmHeight = ((double) (mode->mode.width)) * 25.4 / monitorResolution;
+        mmHeight = ((double) (mode->mode.height)) * 25.4 / monitorResolution;
         RROutputSetModes(output, &mode, 1, 0);
         RRCrtcNotify(RRFirstEnabledCrtc(pScreen), mode, 0, 0, RR_Rotate_0, NULL, 1, &output);
         RRScreenSizeSet(pScreen, mode->mode.width, mode->mode.height, mmWidth, mmHeight);

--- a/app/src/main/cpp/lorie/activity.c
+++ b/app/src/main/cpp/lorie/activity.c
@@ -382,11 +382,16 @@ static void surfaceChanged(JNIEnv *env, __unused jobject thiz, jobject sfc) {
     rendererSetWindow(win);
 }
 
+static void requestRender(__unused JNIEnv *env, __unused jobject thiz) {
+    lorieRequestRender();
+}
+
 JNIEXPORT jint JNI_OnLoad(JavaVM *vm, __unused void *reserved) {
     JNIEnv* env;
     static JNINativeMethod methods[] = {
             {"nativeInit", "()V", (void *)&nativeInit},
             {"surfaceChanged", "(Landroid/view/Surface;)V", (void *)&surfaceChanged},
+            {"requestRender", "()V", (void *)&requestRender},
             {"setFiltering", "(I)V", (void *)&rendererSetFiltering},
             {"connect", "(I)V", (void *)&connect_},
             {"connected", "()Z", (void *)&connected},
@@ -407,6 +412,8 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *vm, __unused void *reserved) {
     jclass cls = (*env)->FindClass(env, "com/termux/x11/LorieView");
     (*env)->RegisterNatives(env, cls, methods, sizeof(methods)/sizeof(methods[0]));
 
+    rendererSetJavaVm(vm);
+    rendererInitDisplayLinkBridge(env);
     rendererInit(env);
 
     return JNI_VERSION_1_6;

--- a/app/src/main/cpp/lorie/lorie.h
+++ b/app/src/main/cpp/lorie/lorie.h
@@ -31,10 +31,16 @@ void lorieSetStylusEnabled(Bool enabled);
 void lorieWakeServer(void);
 void lorieChoreographerFrameCallback(__unused long t, AChoreographer* d);
 void lorieActivityConnected(void);
+void lorieRequestRender(void);
 void lorieSendSharedServerState(int memfd);
 void lorieRegisterBuffer(LorieBuffer* buffer);
 void lorieUnregisterBuffer(LorieBuffer* buffer);
 bool lorieConnectionAlive(void);
+bool displaylinkSinkEnabled(void);
+bool displaylinkSinkFrame(const struct lorie_shared_server_state* state, LorieBuffer* buffer, const LorieBuffer_Desc* desc,
+                          bool drawRequested, bool cursorUpdated, bool cursorMoved);
+void rendererSetJavaVm(JavaVM* vm);
+void rendererInitDisplayLinkBridge(JNIEnv* env);
 
 __unused void rendererInit(JNIEnv* env);
 __unused void rendererSetFiltering(JNIEnv* env, jobject self, jint filtering);

--- a/app/src/main/cpp/lorie/renderer.c
+++ b/app/src/main/cpp/lorie/renderer.c
@@ -19,6 +19,12 @@
 #include <media/NdkImageReader.h>
 #include <dlfcn.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <limits.h>
+#include <string.h>
+#include <time.h>
 #include "list.h"
 #include "lorie.h"
 
@@ -118,6 +124,16 @@ static volatile struct xorg_list addedBuffers, buffers, removedBuffers;
 volatile jint filtering = GL_NEAREST;
 
 static JNIEnv* renderEnv = NULL;
+static JavaVM* rendererVm = NULL;
+static jclass displayLinkBridgeClass = NULL;
+static jmethodID displayLinkPushFrameMethod = NULL;
+static jmethodID displayLinkCaptureReadyMethod = NULL;
+static jmethodID displayLinkCaptureWidthMethod = NULL;
+static jmethodID displayLinkCaptureHeightMethod = NULL;
+static GLuint displaylinkSinkFramebuffer = 0;
+static GLuint displaylinkSinkFramebufferTexture = 0;
+static int displaylinkSinkFramebufferWidth = 0;
+static int displaylinkSinkFramebufferHeight = 0;
 static volatile bool stateChanged = false, windowChanged = false;
 static volatile struct lorie_shared_server_state* pendingState = NULL;
 static volatile ANativeWindow* pendingWin = NULL;
@@ -132,14 +148,701 @@ static struct {
     bool cursorChanged;
 } cursor;
 
+static volatile bool displaylinkSinkChecked = false;
+static volatile bool displaylinkSinkEnabledCached = false;
+static int displaylinkSinkFrameCounter = 0;
+static int displaylinkSinkAttemptCounter = 0;
+static const int displaylinkSinkMaxFrames = 0;
+static volatile bool displaylinkSinkLogged = false;
+static char displaylinkSinkOutputDir[PATH_MAX] = {0};
+static int displaylinkSinkCheckCount = 0;
+static int displaylinkSinkProbeCount = 0;
+static volatile bool displaylinkSinkCapturePending = false;
+static volatile bool displaylinkSinkCaptureInProgress = false;
+static int displaylinkSinkCaptureWidth = 0;
+static int displaylinkSinkCaptureHeight = 0;
+static int displaylinkSinkJavaDiagCount = 0;
+static uint8_t* displaylinkSinkPostBuffer = NULL;
+static size_t displaylinkSinkPostBufferSize = 0;
+
 GLuint g_texture_program = 0, gv_pos = 0, gv_coords = 0;
 GLuint g_texture_program_bgra = 0, gv_pos_bgra = 0, gv_coords_bgra = 0;
 
 static void* rendererThread(void);
+static void draw(GLuint id, float x0, float y0, float x1, float y1, float xfactor, uint8_t flip);
+static void drawCursor(float displayWidth, float displayHeight);
+static void displaylinkSinkDumpFrame(const uint8_t* pixels, int width, int height);
+static bool displaylinkSinkMarkerExists(const char* path);
+static bool displaylinkSinkDirWritable(const char* path);
+static const char* displaylinkSinkResolveOutputDir(void);
+static void displaylinkSinkWriteAliveMarker(void);
+static void displaylinkSinkWriteJavaDiag(const char* message);
+static void displaylinkSinkDumpCurrentFramebuffer(int width, int height);
+static bool displaylinkSinkPostCurrentFramebuffer(int width, int height);
+static bool displaylinkSinkPostFrameToJava(const uint8_t* pixels, int width, int height, int rowStride);
+static bool displaylinkSinkEnsureFramebuffer(int width, int height);
+static bool displaylinkSinkRenderAndPostFramebuffer(LorieBuffer* buffer, const LorieBuffer_Desc* desc, float xfactor, int width, int height);
+static void displaylinkSinkDrawCursorLetterboxed(int sourceWidth, int sourceHeight, int targetWidth, int targetHeight);
 
 static void pthreadCondVarProxyInit(void);
 static void* pthreadCondVarProxyThread(void* cookie);
 static void pthreadCondVarProxyListenOtherCondVar(pthread_cond_t* var);
+
+static bool displaylinkSinkMarkerExists(const char* path) {
+    return path && access(path, F_OK) == 0;
+}
+
+static bool displaylinkSinkDirWritable(const char* path) {
+    return path && access(path, W_OK | X_OK) == 0;
+}
+
+static const char* displaylinkSinkResolveOutputDir(void) {
+    const char* tmpdir = getenv("TMPDIR");
+    const char* candidates[] = {
+        tmpdir,
+        "/sdcard/Download",
+        "/data/local/tmp",
+        "/tmp",
+        NULL,
+    };
+
+    if (displaylinkSinkOutputDir[0])
+        return displaylinkSinkOutputDir;
+
+    for (int i = 0; candidates[i]; ++i) {
+        if (displaylinkSinkDirWritable(candidates[i])) {
+            snprintf(displaylinkSinkOutputDir, sizeof(displaylinkSinkOutputDir), "%s", candidates[i]);
+            return displaylinkSinkOutputDir;
+        }
+    }
+
+    snprintf(displaylinkSinkOutputDir, sizeof(displaylinkSinkOutputDir), "%s", "/tmp");
+    return displaylinkSinkOutputDir;
+}
+
+static void displaylinkSinkWriteAliveMarker(void) {
+    const char* outDir = displaylinkSinkResolveOutputDir();
+    char path[PATH_MAX];
+    int fd;
+
+    if (!outDir)
+        return;
+
+    snprintf(path, sizeof(path), "%s/termux-x11-sink-alive.txt", outDir);
+    fd = open(path, O_CREAT | O_TRUNC | O_WRONLY | O_CLOEXEC, 0644);
+    if (fd < 0)
+        return;
+
+    dprintf(fd, "sink alive pid=%d\n", getpid());
+    close(fd);
+}
+
+static void displaylinkSinkWriteJavaDiag(const char* message) {
+    const char* outDir = displaylinkSinkResolveOutputDir();
+    char path[PATH_MAX];
+    int fd;
+
+    if (!outDir || !message)
+        return;
+
+    snprintf(path, sizeof(path), "%s/displaylink-java-diag.log", outDir);
+    fd = open(path, O_CREAT | O_APPEND | O_WRONLY | O_CLOEXEC, 0644);
+    if (fd < 0)
+        return;
+
+    dprintf(fd, "%ld %s\n", (long) time(NULL), message);
+    close(fd);
+}
+
+bool displaylinkSinkEnabled(void) {
+    if (!displaylinkSinkChecked) {
+        const char* enabled = getenv("TERMUX_X11_DISPLAYLINK_SINK");
+        const char* tmpdir = getenv("TMPDIR");
+        char markerPath[PATH_MAX] = {0};
+        const char* fallbackMarker = "/sdcard/Download/.termux-x11-displaylink-sink";
+        const char* fallbackMarkerAlt = "/data/local/tmp/.termux-x11-displaylink-sink";
+
+        if (tmpdir && snprintf(markerPath, sizeof(markerPath), "%s/.termux-x11-displaylink-sink", tmpdir) >= (int) sizeof(markerPath))
+            markerPath[0] = '\0';
+
+        ++displaylinkSinkCheckCount;
+        log("DisplayLink sink check #%d: env=%s tmpdir=%s marker=%s fallback=%s alt=%s",
+            displaylinkSinkCheckCount,
+            enabled ?: "(null)",
+            tmpdir ?: "(null)",
+            markerPath[0] ? markerPath : "(null)",
+            fallbackMarker,
+            fallbackMarkerAlt);
+
+        displaylinkSinkEnabledCached =
+            (enabled && strcmp(enabled, "1") == 0) ||
+            displaylinkSinkMarkerExists(markerPath[0] ? markerPath : NULL) ||
+            displaylinkSinkMarkerExists(fallbackMarker) ||
+            displaylinkSinkMarkerExists(fallbackMarkerAlt);
+        displaylinkSinkChecked = true;
+        if (displaylinkSinkEnabledCached && !displaylinkSinkLogged) {
+            if (enabled && strcmp(enabled, "1") == 0)
+                log("DisplayLink sink enabled via TERMUX_X11_DISPLAYLINK_SINK=1.");
+            else if (displaylinkSinkMarkerExists(markerPath[0] ? markerPath : NULL))
+                log("DisplayLink sink enabled via marker file %s.", markerPath);
+            else if (displaylinkSinkMarkerExists(fallbackMarker))
+                log("DisplayLink sink enabled via marker file %s.", fallbackMarker);
+            else
+                log("DisplayLink sink enabled via marker file %s.", fallbackMarkerAlt);
+            log("Frames will be dumped to %s for integration testing.", displaylinkSinkResolveOutputDir());
+            displaylinkSinkWriteAliveMarker();
+            displaylinkSinkLogged = true;
+        } else {
+            log("DisplayLink sink disabled after marker/env check.");
+        }
+    }
+
+    return displaylinkSinkEnabledCached;
+}
+
+void rendererSetJavaVm(JavaVM* vm) {
+    rendererVm = vm;
+    displaylinkSinkWriteJavaDiag(vm ? "rendererSetJavaVm: vm ready" : "rendererSetJavaVm: vm null");
+}
+
+void rendererInitDisplayLinkBridge(JNIEnv* env) {
+    jclass localClass;
+
+    if (displayLinkBridgeClass && displayLinkPushFrameMethod && displayLinkCaptureReadyMethod &&
+        displayLinkCaptureWidthMethod && displayLinkCaptureHeightMethod)
+        return;
+
+    localClass = (*env)->FindClass(env, "com/termux/x11/displaylink/DisplayLinkBridge");
+    if (!localClass) {
+        if ((*env)->ExceptionCheck(env)) {
+            (*env)->ExceptionDescribe(env);
+            (*env)->ExceptionClear(env);
+        }
+        loge("DisplayLink sink: failed to resolve DisplayLinkBridge class");
+        displaylinkSinkWriteJavaDiag("rendererInitDisplayLinkBridge: class lookup failed");
+        return;
+    }
+
+    displayLinkBridgeClass = (*env)->NewGlobalRef(env, localClass);
+    (*env)->DeleteLocalRef(env, localClass);
+    if (!displayLinkBridgeClass) {
+        loge("DisplayLink sink: failed to create global DisplayLinkBridge ref");
+        displaylinkSinkWriteJavaDiag("rendererInitDisplayLinkBridge: global ref failed");
+        return;
+    }
+
+    displayLinkPushFrameMethod = (*env)->GetStaticMethodID(env, displayLinkBridgeClass, "pushFrame", "(Ljava/nio/ByteBuffer;III)Z");
+    if (!displayLinkPushFrameMethod) {
+        if ((*env)->ExceptionCheck(env)) {
+            (*env)->ExceptionDescribe(env);
+            (*env)->ExceptionClear(env);
+        }
+        loge("DisplayLink sink: failed to resolve DisplayLinkBridge.pushFrame");
+        displaylinkSinkWriteJavaDiag("rendererInitDisplayLinkBridge: pushFrame method lookup failed");
+        return;
+    }
+
+    displayLinkCaptureReadyMethod = (*env)->GetStaticMethodID(env, displayLinkBridgeClass, "isCaptureReady", "()Z");
+    if (!displayLinkCaptureReadyMethod) {
+        if ((*env)->ExceptionCheck(env)) {
+            (*env)->ExceptionDescribe(env);
+            (*env)->ExceptionClear(env);
+        }
+        loge("DisplayLink sink: failed to resolve DisplayLinkBridge.isCaptureReady");
+        displaylinkSinkWriteJavaDiag("rendererInitDisplayLinkBridge: isCaptureReady method lookup failed");
+        return;
+    }
+
+    displayLinkCaptureWidthMethod = (*env)->GetStaticMethodID(env, displayLinkBridgeClass, "getCaptureWidth", "()I");
+    if (!displayLinkCaptureWidthMethod) {
+        if ((*env)->ExceptionCheck(env)) {
+            (*env)->ExceptionDescribe(env);
+            (*env)->ExceptionClear(env);
+        }
+        loge("DisplayLink sink: failed to resolve DisplayLinkBridge.getCaptureWidth");
+        displaylinkSinkWriteJavaDiag("rendererInitDisplayLinkBridge: getCaptureWidth method lookup failed");
+        return;
+    }
+
+    displayLinkCaptureHeightMethod = (*env)->GetStaticMethodID(env, displayLinkBridgeClass, "getCaptureHeight", "()I");
+    if (!displayLinkCaptureHeightMethod) {
+        if ((*env)->ExceptionCheck(env)) {
+            (*env)->ExceptionDescribe(env);
+            (*env)->ExceptionClear(env);
+        }
+        loge("DisplayLink sink: failed to resolve DisplayLinkBridge.getCaptureHeight");
+        displaylinkSinkWriteJavaDiag("rendererInitDisplayLinkBridge: getCaptureHeight method lookup failed");
+        return;
+    }
+
+    displaylinkSinkWriteJavaDiag("rendererInitDisplayLinkBridge: pushFrame ready");
+}
+
+static bool displaylinkSinkCaptureReady(void) {
+    JNIEnv* env = NULL;
+    bool attached = false;
+    jboolean ready = JNI_FALSE;
+
+    if (!rendererVm || !displayLinkBridgeClass || !displayLinkCaptureReadyMethod)
+        return false;
+
+    if ((*rendererVm)->GetEnv(rendererVm, (void**) &env, JNI_VERSION_1_6) != JNI_OK) {
+        if ((*rendererVm)->AttachCurrentThread(rendererVm, &env, NULL) != JNI_OK)
+            return false;
+        attached = true;
+    }
+
+    ready = (*env)->CallStaticBooleanMethod(env, displayLinkBridgeClass, displayLinkCaptureReadyMethod);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+        ready = JNI_FALSE;
+    }
+
+    if (attached)
+        (*rendererVm)->DetachCurrentThread(rendererVm);
+    return ready == JNI_TRUE;
+}
+
+static bool displaylinkSinkGetTargetSize(int* width, int* height) {
+    JNIEnv* env = NULL;
+    bool attached = false;
+    jint captureWidth = 0;
+    jint captureHeight = 0;
+
+    if (!rendererVm || !displayLinkBridgeClass || !displayLinkCaptureWidthMethod || !displayLinkCaptureHeightMethod)
+        return false;
+
+    if ((*rendererVm)->GetEnv(rendererVm, (void**) &env, JNI_VERSION_1_6) != JNI_OK) {
+        if ((*rendererVm)->AttachCurrentThread(rendererVm, &env, NULL) != JNI_OK)
+            return false;
+        attached = true;
+    }
+
+    captureWidth = (*env)->CallStaticIntMethod(env, displayLinkBridgeClass, displayLinkCaptureWidthMethod);
+    captureHeight = (*env)->CallStaticIntMethod(env, displayLinkBridgeClass, displayLinkCaptureHeightMethod);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+        captureWidth = 0;
+        captureHeight = 0;
+    }
+
+    if (attached)
+        (*rendererVm)->DetachCurrentThread(rendererVm);
+
+    if (captureWidth <= 0 || captureHeight <= 0)
+        return false;
+
+    *width = captureWidth;
+    *height = captureHeight;
+    return true;
+}
+
+static bool displaylinkSinkEnsureFramebuffer(int width, int height) {
+    GLint previousTexture = 0;
+    GLint previousFramebuffer = 0;
+
+    if (width <= 0 || height <= 0)
+        return false;
+
+    if (!displaylinkSinkFramebuffer)
+        glGenFramebuffers(1, &displaylinkSinkFramebuffer);
+    if (!displaylinkSinkFramebufferTexture)
+        glGenTextures(1, &displaylinkSinkFramebufferTexture);
+
+    if (!displaylinkSinkFramebuffer || !displaylinkSinkFramebufferTexture)
+        return false;
+
+    if (displaylinkSinkFramebufferWidth == width && displaylinkSinkFramebufferHeight == height)
+        return true;
+
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &previousTexture);
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &previousFramebuffer);
+
+    glBindTexture(GL_TEXTURE_2D, displaylinkSinkFramebufferTexture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, displaylinkSinkFramebuffer);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, displaylinkSinkFramebufferTexture, 0);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        glBindFramebuffer(GL_FRAMEBUFFER, previousFramebuffer);
+        glBindTexture(GL_TEXTURE_2D, previousTexture);
+        return false;
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, previousFramebuffer);
+    glBindTexture(GL_TEXTURE_2D, previousTexture);
+
+    displaylinkSinkFramebufferWidth = width;
+    displaylinkSinkFramebufferHeight = height;
+    return true;
+}
+
+static void displaylinkSinkDrawLetterboxed(GLuint textureId, uint8_t flip, float xfactor,
+                                           int sourceWidth, int sourceHeight,
+                                           int targetWidth, int targetHeight) {
+    float sourceAspect;
+    float targetAspect;
+    float drawWidth;
+    float drawHeight;
+    float left;
+    float right;
+    float top;
+    float bottom;
+
+    if (sourceWidth <= 0 || sourceHeight <= 0 || targetWidth <= 0 || targetHeight <= 0)
+        return;
+
+    sourceAspect = (float) sourceWidth / (float) sourceHeight;
+    targetAspect = (float) targetWidth / (float) targetHeight;
+
+    if (sourceAspect > targetAspect) {
+        drawWidth = 2.f;
+        drawHeight = 2.f * (targetAspect / sourceAspect);
+    } else {
+        drawHeight = 2.f;
+        drawWidth = 2.f * (sourceAspect / targetAspect);
+    }
+
+    left = -drawWidth * 0.5f;
+    right = drawWidth * 0.5f;
+    top = -drawHeight * 0.5f;
+    bottom = drawHeight * 0.5f;
+    draw(textureId, left, top, right, bottom, xfactor, flip);
+}
+
+static void displaylinkSinkDrawCursorLetterboxed(int sourceWidth, int sourceHeight, int targetWidth, int targetHeight) {
+    float sourceAspect;
+    float targetAspect;
+    float drawWidth;
+    float drawHeight;
+    float left;
+    float top;
+    float right;
+    float bottom;
+    float cursorLeft;
+    float cursorTop;
+    float cursorWidth;
+    float cursorHeight;
+
+    if (!state || !state->cursor.width || !state->cursor.height ||
+        sourceWidth <= 0 || sourceHeight <= 0 || targetWidth <= 0 || targetHeight <= 0) {
+        return;
+    }
+
+    sourceAspect = (float) sourceWidth / (float) sourceHeight;
+    targetAspect = (float) targetWidth / (float) targetHeight;
+
+    if (sourceAspect > targetAspect) {
+        drawWidth = 2.f;
+        drawHeight = 2.f * (targetAspect / sourceAspect);
+    } else {
+        drawHeight = 2.f;
+        drawWidth = 2.f * (sourceAspect / targetAspect);
+    }
+
+    left = -drawWidth * 0.5f;
+    top = -drawHeight * 0.5f;
+    right = left + drawWidth;
+    bottom = top + drawHeight;
+
+    cursorLeft = left + drawWidth * (((float) state->cursor.x - (float) state->cursor.xhot) / (float) sourceWidth);
+    cursorTop = top + drawHeight * (((float) state->cursor.y - (float) state->cursor.yhot) / (float) sourceHeight);
+    cursorWidth = drawWidth * ((float) state->cursor.width / (float) sourceWidth);
+    cursorHeight = drawHeight * ((float) state->cursor.height / (float) sourceHeight);
+
+    if (cursorWidth > drawWidth)
+        cursorWidth = drawWidth;
+    if (cursorHeight > drawHeight)
+        cursorHeight = drawHeight;
+
+    if (cursorLeft < left)
+        cursorLeft = left;
+    else if (cursorLeft + cursorWidth > right)
+        cursorLeft = right - cursorWidth;
+
+    if (cursorTop < top)
+        cursorTop = top;
+    else if (cursorTop + cursorHeight > bottom)
+        cursorTop = bottom - cursorHeight;
+
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    draw(cursor.id, cursorLeft, cursorTop, cursorLeft + cursorWidth, cursorTop + cursorHeight, 1.f, false);
+    glDisable(GL_BLEND);
+}
+
+static bool displaylinkSinkRenderAndPostFramebuffer(LorieBuffer* buffer, const LorieBuffer_Desc* desc, float xfactor, int width, int height) {
+    GLint previousFramebuffer = 0;
+    GLint previousViewport[4] = {0};
+    bool posted;
+
+    if (!displaylinkSinkEnsureFramebuffer(width, height))
+        return false;
+
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &previousFramebuffer);
+    glGetIntegerv(GL_VIEWPORT, previousViewport);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, displaylinkSinkFramebuffer);
+    glViewport(0, 0, width, height);
+    glDisable(GL_SCISSOR_TEST);
+    glClearColor(0, 0, 0, 0);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    LorieBuffer_bindTexture(buffer);
+    displaylinkSinkDrawLetterboxed(0, LorieBuffer_isRgba(buffer), xfactor,
+            desc->width, desc->height, width, height);
+    displaylinkSinkDrawCursorLetterboxed(desc->width, desc->height, width, height);
+    glFlush();
+
+    posted = displaylinkSinkPostCurrentFramebuffer(width, height);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, previousFramebuffer);
+    glViewport(previousViewport[0], previousViewport[1], previousViewport[2], previousViewport[3]);
+    return posted;
+}
+
+static void displaylinkSinkDumpFrame(const uint8_t* pixels, int width, int height) {
+    int fd;
+    char path[256];
+    char header[128];
+    int headerLen;
+    const char* outDir;
+
+    if (!pixels || width <= 0 || height <= 0)
+        return;
+
+    outDir = displaylinkSinkResolveOutputDir();
+    snprintf(path, sizeof(path), "%s/frame-%06d.ppm", outDir, displaylinkSinkFrameCounter);
+    fd = open(path, O_CREAT | O_TRUNC | O_WRONLY | O_CLOEXEC, 0644);
+    if (fd < 0) {
+        log("DisplayLink sink: failed to open %s: %s", path, strerror(errno));
+        return;
+    }
+
+    headerLen = snprintf(header, sizeof(header), "P6\n%d %d\n255\n", width, height);
+    if (write(fd, header, headerLen) != headerLen) {
+        close(fd);
+        return;
+    }
+
+    for (int y = height - 1; y >= 0; --y) {
+        const uint8_t* row = pixels + ((size_t) y * (size_t) width * 4);
+        for (int x = 0; x < width; ++x) {
+            const uint8_t* src = row + ((size_t) x * 4);
+            uint8_t pixel[3] = { src[0], src[1], src[2] };
+            if (write(fd, pixel, sizeof(pixel)) != sizeof(pixel)) {
+                close(fd);
+                return;
+            }
+        }
+    }
+
+    log("DisplayLink sink: dumped framebuffer %d (%dx%d) to %s",
+        displaylinkSinkFrameCounter, width, height, path);
+    displaylinkSinkFrameCounter++;
+
+    close(fd);
+}
+
+static void displaylinkSinkDumpCurrentFramebuffer(int width, int height) {
+    uint8_t* pixels;
+
+    if (width <= 0 || height <= 0)
+        return;
+
+    pixels = calloc((size_t) width * (size_t) height, 4);
+    if (!pixels) {
+        loge("DisplayLink sink: failed to allocate framebuffer dump buffer for %dx%d", width, height);
+        return;
+    }
+
+    log("DisplayLink sink: reading framebuffer %dx%d", width, height);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    if (glGetError() != GL_NO_ERROR) {
+        loge("DisplayLink sink: glReadPixels failed for %dx%d", width, height);
+        free(pixels);
+        return;
+    }
+
+    log("DisplayLink sink: framebuffer read completed for %dx%d", width, height);
+    displaylinkSinkDumpFrame(pixels, width, height);
+    free(pixels);
+}
+
+static bool displaylinkSinkPostFrameToJava(const uint8_t* pixels, int width, int height, int rowStride) {
+    JNIEnv* env = NULL;
+    bool attached = false;
+    jobject buffer = NULL;
+    jboolean pushed = JNI_FALSE;
+    size_t bufferSize;
+
+    if (!rendererVm || !displayLinkBridgeClass || !displayLinkPushFrameMethod || !pixels || width <= 0 || height <= 0 || rowStride <= 0) {
+        if (displaylinkSinkJavaDiagCount < 20) {
+            char diag[256];
+            snprintf(diag, sizeof(diag),
+                     "postFrameToJava prereq failed vm=%d class=%d method=%d pixels=%d width=%d height=%d rowStride=%d",
+                     rendererVm != NULL,
+                     displayLinkBridgeClass != NULL,
+                     displayLinkPushFrameMethod != NULL,
+                     pixels != NULL,
+                     width,
+                     height,
+                     rowStride);
+            displaylinkSinkWriteJavaDiag(diag);
+            displaylinkSinkJavaDiagCount++;
+        }
+        return false;
+    }
+
+    if ((*rendererVm)->GetEnv(rendererVm, (void**) &env, JNI_VERSION_1_6) != JNI_OK) {
+        if ((*rendererVm)->AttachCurrentThread(rendererVm, &env, NULL) != JNI_OK)
+            return false;
+        attached = true;
+    }
+
+    bufferSize = (size_t) rowStride * (size_t) height;
+    buffer = (*env)->NewDirectByteBuffer(env, (void*) pixels, (jlong) bufferSize);
+    if (!buffer)
+        goto done;
+
+    if (displaylinkSinkJavaDiagCount < 20) {
+        char diag[256];
+        snprintf(diag, sizeof(diag), "postFrameToJava invoking width=%d height=%d rowStride=%d size=%zu", width, height, rowStride, bufferSize);
+        displaylinkSinkWriteJavaDiag(diag);
+        displaylinkSinkJavaDiagCount++;
+    }
+
+    pushed = (*env)->CallStaticBooleanMethod(env, displayLinkBridgeClass, displayLinkPushFrameMethod, buffer, width, height, rowStride);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+        pushed = JNI_FALSE;
+        displaylinkSinkWriteJavaDiag("postFrameToJava exception from CallStaticBooleanMethod");
+    } else if (displaylinkSinkJavaDiagCount < 20) {
+        displaylinkSinkWriteJavaDiag(pushed == JNI_TRUE ? "postFrameToJava returned true" : "postFrameToJava returned false");
+        displaylinkSinkJavaDiagCount++;
+    }
+
+done:
+    if (buffer)
+        (*env)->DeleteLocalRef(env, buffer);
+    if (attached)
+        (*rendererVm)->DetachCurrentThread(rendererVm);
+    return pushed == JNI_TRUE;
+}
+
+static bool displaylinkSinkPostCurrentFramebuffer(int width, int height) {
+    uint8_t* pixels;
+    bool posted;
+    int rowStride;
+    size_t requiredSize;
+
+    if (width <= 0 || height <= 0)
+        return false;
+
+    rowStride = width * 4;
+    requiredSize = (size_t) rowStride * (size_t) height;
+    if (displaylinkSinkPostBuffer == NULL || displaylinkSinkPostBufferSize < requiredSize) {
+        uint8_t* replacement = realloc(displaylinkSinkPostBuffer, requiredSize);
+        if (!replacement) {
+            loge("DisplayLink sink: failed to grow framebuffer post buffer for %dx%d", width, height);
+            return false;
+        }
+        displaylinkSinkPostBuffer = replacement;
+        displaylinkSinkPostBufferSize = requiredSize;
+    }
+
+    pixels = displaylinkSinkPostBuffer;
+    if (!pixels) {
+        loge("DisplayLink sink: failed to allocate framebuffer post buffer for %dx%d", width, height);
+        return false;
+    }
+
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    if (glGetError() != GL_NO_ERROR) {
+        loge("DisplayLink sink: glReadPixels failed for postFrame %dx%d", width, height);
+        return false;
+    }
+
+    posted = displaylinkSinkPostFrameToJava(pixels, width, height, rowStride);
+    if (!posted)
+        log("DisplayLink sink: Java postFrame path not ready for %dx%d", width, height);
+    return posted;
+}
+
+bool displaylinkSinkFrame(const struct lorie_shared_server_state* sharedState, LorieBuffer* buffer, const LorieBuffer_Desc* desc,
+                          bool drawRequested, bool cursorUpdated, bool cursorMoved) {
+    static uint64_t lastFrameId = 0;
+    static uint8_t lastCursorUpdated = 0;
+    static uint8_t lastCursorMoved = 0;
+    int targetWidth = 0;
+    int targetHeight = 0;
+
+    if (!displaylinkSinkEnabled() || !sharedState || !buffer || !desc) {
+        log("DisplayLink sink skipped: enabled=%d state=%p buffer=%p desc=%p",
+            displaylinkSinkEnabled(), sharedState, buffer, desc);
+        return false;
+    }
+
+    if (!displaylinkSinkCaptureReady()) {
+        return false;
+    }
+
+    if (!displaylinkSinkGetTargetSize(&targetWidth, &targetHeight)) {
+        return false;
+    }
+
+    if (displaylinkSinkMaxFrames > 0 && displaylinkSinkFrameCounter >= displaylinkSinkMaxFrames) {
+        log("DisplayLink sink skipped: frame limit reached (%d/%d)",
+            displaylinkSinkFrameCounter, displaylinkSinkMaxFrames);
+        return false;
+    }
+
+    if (!drawRequested &&
+        lastFrameId == desc->id &&
+        lastCursorUpdated == cursorUpdated &&
+        lastCursorMoved == cursorMoved) {
+        log("DisplayLink sink skipped: no new frame state for id=%llu",
+            (unsigned long long) desc->id);
+        return false;
+    }
+
+    lastFrameId = desc->id;
+    lastCursorUpdated = cursorUpdated;
+    lastCursorMoved = cursorMoved;
+
+    if (displaylinkSinkCaptureInProgress) {
+        displaylinkSinkCapturePending = true;
+        displaylinkSinkCaptureWidth = targetWidth;
+        displaylinkSinkCaptureHeight = targetHeight;
+        return false;
+    }
+
+    log("DisplayLink sink frame candidate: id=%llu size=%dx%d stride=%d fmt=%d type=%d draw=%d cursorU=%d cursorM=%d out=%s",
+        (unsigned long long) desc->id,
+        desc->width,
+        desc->height,
+        desc->stride,
+        desc->format,
+        desc->type,
+        drawRequested,
+        cursorUpdated,
+        cursorMoved,
+        displaylinkSinkResolveOutputDir());
+    displaylinkSinkAttemptCounter++;
+    log("DisplayLink sink attempt #%d queued", displaylinkSinkAttemptCounter);
+
+    displaylinkSinkCapturePending = true;
+    displaylinkSinkCaptureWidth = targetWidth;
+    displaylinkSinkCaptureHeight = targetHeight;
+    return true;
+}
 
 static inline __always_inline void bindTexture(GLuint id) {
     glBindTexture(GL_TEXTURE_2D, id);
@@ -176,6 +879,24 @@ int rendererInitThread(void) {
     AImageReader* reader = NULL; // We will use this ImageReader each time surface is destroyed, zero reasons to clean it up
 
     pthread_setname_np(pthread_self(), "LorieRendererThread");
+
+    displaylinkSinkFrameCounter = 0;
+    displaylinkSinkAttemptCounter = 0;
+    displaylinkSinkCapturePending = false;
+    displaylinkSinkCaptureInProgress = false;
+    displaylinkSinkCaptureWidth = 0;
+    displaylinkSinkCaptureHeight = 0;
+    if (displaylinkSinkFramebuffer)
+        glDeleteFramebuffers(1, &displaylinkSinkFramebuffer);
+    if (displaylinkSinkFramebufferTexture)
+        glDeleteTextures(1, &displaylinkSinkFramebufferTexture);
+    displaylinkSinkFramebuffer = 0;
+    displaylinkSinkFramebufferTexture = 0;
+    displaylinkSinkFramebufferWidth = 0;
+    displaylinkSinkFramebufferHeight = 0;
+    free(displaylinkSinkPostBuffer);
+    displaylinkSinkPostBuffer = NULL;
+    displaylinkSinkPostBufferSize = 0;
 
     xorg_list_init(&addedBuffers);
     xorg_list_init(&buffers);
@@ -523,8 +1244,12 @@ static void drawCursor(float displayWidth, float displayHeight);
 
 void rendererRedrawLocked(bool* waitingForBuffers) {
     float xfactor = 1.f;
-    LorieBuffer_Desc *desc = NULL;
+    const LorieBuffer_Desc *desc = NULL;
+    LorieBuffer_Desc descStorage;
     EGLSync fence;
+    bool drawRequested = false;
+    bool cursorUpdated = false;
+    bool cursorMoved = false;
     // The buffer will not be released until this function ends, but main thread can modify buffer list
     pthread_spin_lock(&bufferLock);
     LorieBuffer *buffer = LorieBufferList_findById(&buffers, state->rootWindowTextureID);
@@ -533,58 +1258,91 @@ void rendererRedrawLocked(bool* waitingForBuffers) {
         buffer = LorieBufferList_findById(&removedBuffers, state->rootWindowTextureID);
     if (!buffer)
         *waitingForBuffers = true;
+    else
+        LorieBuffer_acquire(buffer);
     pthread_spin_unlock(&bufferLock);
     if (!buffer) {
         log("Buffer %llu not found", state->rootWindowTextureID);
         return;
     }
 
-    desc = LorieBuffer_description(buffer);
+    descStorage = *LorieBuffer_description(buffer);
+    desc = &descStorage;
 
     // We should signal X server to not use root window while we actively copy it
     lorie_mutex_lock(&state->lock, &state->lockingPid);
+    drawRequested = state->drawRequested;
+    cursorUpdated = state->cursor.updated;
+    cursorMoved = state->cursor.moved;
+    log("rendererRedrawLocked: id=%llu surface=%d draw=%d cursorU=%d cursorM=%d",
+        (unsigned long long) state->rootWindowTextureID,
+        state->surfaceAvailable,
+        drawRequested,
+        cursorUpdated,
+        cursorMoved);
     state->drawRequested = FALSE;
 
-    LorieBuffer_bindTexture(buffer);
-    if (desc->type == LORIEBUFFER_FD)
-        xfactor = (float) desc->width/(float) desc->stride;
-    draw(0, -1.f, -1.f, 1.f, 1.f, xfactor, LorieBuffer_isRgba(buffer));
-    fence = eglCreateSyncKHR(egl_display, EGL_SYNC_FENCE_KHR, NULL);
-    glFlush();
+    displaylinkSinkFrame((const struct lorie_shared_server_state*) state, buffer, desc, drawRequested, cursorUpdated, cursorMoved);
 
-    if (state->cursor.updated) {
-        log("Xlorie: updating cursor\n");
-        lorie_mutex_lock(&state->cursor.lock, &state->cursor.lockingPid);
-        state->cursor.updated = false;
-        bindTexture(cursor.id);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (GLsizei) state->cursor.width, (GLsizei) state->cursor.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, state->cursor.bits);
-        lorie_mutex_unlock(&state->cursor.lock, &state->cursor.lockingPid);
+    if (state->surfaceAvailable) {
+        LorieBuffer_bindTexture(buffer);
+        if (desc->type == LORIEBUFFER_FD)
+            xfactor = (float) desc->width/(float) desc->stride;
+        draw(0, -1.f, -1.f, 1.f, 1.f, xfactor, LorieBuffer_isRgba(buffer));
+        fence = eglCreateSyncKHR(egl_display, EGL_SYNC_FENCE_KHR, NULL);
+        glFlush();
+
+        if (state->cursor.updated) {
+            log("Xlorie: updating cursor\n");
+            lorie_mutex_lock(&state->cursor.lock, &state->cursor.lockingPid);
+            state->cursor.updated = false;
+            bindTexture(cursor.id);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (GLsizei) state->cursor.width, (GLsizei) state->cursor.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, state->cursor.bits);
+            lorie_mutex_unlock(&state->cursor.lock, &state->cursor.lockingPid);
+        }
+
+        state->cursor.moved = FALSE;
+        drawCursor((float) (LorieBuffer_getWidth(buffer)), (float) (LorieBuffer_getHeight(buffer)));
+        glFlush();
+        if (displaylinkSinkCapturePending) {
+            displaylinkSinkCaptureInProgress = true;
+            if (!displaylinkSinkRenderAndPostFramebuffer(buffer, desc, xfactor,
+                    displaylinkSinkCaptureWidth, displaylinkSinkCaptureHeight))
+                displaylinkSinkDumpCurrentFramebuffer(displaylinkSinkCaptureWidth, displaylinkSinkCaptureHeight);
+            displaylinkSinkCaptureInProgress = false;
+            displaylinkSinkCapturePending = false;
+        }
+
+        // Wait until root window drawing is finished before giving control back to X server
+        eglClientWaitSyncKHR(egl_display, fence, 0, EGL_FOREVER);
+        eglDestroySyncKHR(egl_display, fence);
+        state->waitForNextFrame = true;
+    } else {
+        displaylinkSinkCapturePending = false;
+        displaylinkSinkCaptureInProgress = false;
+        state->cursor.updated = FALSE;
+        state->cursor.moved = FALSE;
+        state->waitForNextFrame = false;
     }
-
-    state->cursor.moved = FALSE;
-    drawCursor((float) (LorieBuffer_getWidth(buffer)), (float) (LorieBuffer_getHeight(buffer)));
-    glFlush();
-
-    // Wait until root window drawing is finished before giving control back to X server
-    eglClientWaitSyncKHR(egl_display, fence, 0, EGL_FOREVER);
-    eglDestroySyncKHR(egl_display, fence);
-    state->waitForNextFrame = true;
     lorie_mutex_unlock(&state->lock, &state->lockingPid);
 
-    if (eglSwapBuffers(egl_display, sfc) != EGL_TRUE)
-        printEglError("Failed to swap buffers", __LINE__);
+    if (state->surfaceAvailable) {
+        if (eglSwapBuffers(egl_display, sfc) != EGL_TRUE)
+            printEglError("Failed to swap buffers", __LINE__);
 
-    // Perform a little drawing operation to make sure the next buffer is ready on the next invocation of drawing
-    glEnable(GL_SCISSOR_TEST);
-    glScissor(0, 0, 1, 1);
-    glClearColor(0, 0, 0, 0);
-    glClear(GL_COLOR_BUFFER_BIT);
-    glDisable(GL_SCISSOR_TEST);
-    fence = eglCreateSyncKHR(egl_display, EGL_SYNC_FENCE_KHR, NULL);
-    eglClientWaitSyncKHR(egl_display, fence, EGL_SYNC_FLUSH_COMMANDS_BIT_KHR, EGL_FOREVER);
-    eglDestroySyncKHR(egl_display, fence);
+        // Perform a little drawing operation to make sure the next buffer is ready on the next invocation of drawing
+        glEnable(GL_SCISSOR_TEST);
+        glScissor(0, 0, 1, 1);
+        glClearColor(0, 0, 0, 0);
+        glClear(GL_COLOR_BUFFER_BIT);
+        glDisable(GL_SCISSOR_TEST);
+        fence = eglCreateSyncKHR(egl_display, EGL_SYNC_FENCE_KHR, NULL);
+        eglClientWaitSyncKHR(egl_display, fence, EGL_SYNC_FLUSH_COMMANDS_BIT_KHR, EGL_FOREVER);
+        eglDestroySyncKHR(egl_display, fence);
+    }
 
     state->renderedFrames++;
+    LorieBuffer_release(buffer);
 }
 
 static inline __always_inline bool rendererShouldWait(bool *waitingForBuffers) {
@@ -603,7 +1361,7 @@ static inline __always_inline bool rendererShouldWait(bool *waitingForBuffers) {
         lastRequestedBufferId = state->rootWindowTextureID;
     }
 
-    if (!state || !state->surfaceAvailable || state->waitForNextFrame || *waitingForBuffers)
+    if (!state || ((!state->surfaceAvailable && !displaylinkSinkEnabled())) || state->waitForNextFrame || *waitingForBuffers)
         // Even in the case if there are pending changes, we can not draw it without rendering surface
         return true;
 
@@ -654,6 +1412,17 @@ __noreturn static void* rendererThread(void) {
         while((buf = LorieBufferList_first(&addedBuffers))) {
             LorieBuffer_attachToGL(buf);
             LorieBuffer_addToList(buf, &buffers);
+            if (displaylinkSinkEnabled() && displaylinkSinkProbeCount < 8) {
+                const LorieBuffer_Desc* attachedDesc = LorieBuffer_description(buf);
+                log("DisplayLink sink probe on attached buffer: id=%llu size=%dx%d stride=%d fmt=%d type=%d",
+                    (unsigned long long) attachedDesc->id,
+                    attachedDesc->width,
+                    attachedDesc->height,
+                    attachedDesc->stride,
+                    attachedDesc->format,
+                    attachedDesc->type);
+                displaylinkSinkProbeCount++;
+            }
             waitingForBuffers = false;
         }
         pthread_spin_unlock(&bufferLock);
@@ -661,7 +1430,7 @@ __noreturn static void* rendererThread(void) {
         pthread_cond_signal(&stateChangeFinishCond);
         pthread_mutex_unlock(&stateLock);
 
-        if (state && state->surfaceAvailable && !state->waitForNextFrame && (state->drawRequested || state->cursor.moved || state->cursor.updated))
+        if (state && (state->surfaceAvailable || displaylinkSinkEnabled()) && !state->waitForNextFrame && (state->drawRequested || state->cursor.moved || state->cursor.updated))
             rendererRedrawLocked(&waitingForBuffers);
 
         pthread_spin_lock(&bufferLock);

--- a/app/src/main/java/com/displaylink/manager/NativeDriver.java
+++ b/app/src/main/java/com/displaylink/manager/NativeDriver.java
@@ -1,0 +1,77 @@
+package com.displaylink.manager;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.util.Log;
+import android.view.Surface;
+
+import androidx.annotation.Keep;
+
+import com.displaylink.manager.display.DisplayMode;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+
+@Keep
+public class NativeDriver {
+    private static final String TAG = "DisplayLinkNativeDriver";
+    private static final String DISPLAYLINK_PACKAGE = "com.displaylink.presenter";
+    private static final String[] REQUIRED_LIBS = {
+        "libusb_android.so",
+        "libAndroidDLM.so",
+        "libDisplayLinkManager.so",
+    };
+
+    private static volatile boolean sLoaded;
+
+    public static synchronized void ensureLoaded(Context context) throws PackageManager.NameNotFoundException {
+        if (sLoaded) {
+            return;
+        }
+
+        ApplicationInfo info = context.getPackageManager().getApplicationInfo(DISPLAYLINK_PACKAGE, 0);
+        String nativeLibraryDir = info.nativeLibraryDir;
+        if (nativeLibraryDir == null) {
+            throw new IllegalStateException("DisplayLink nativeLibraryDir missing");
+        }
+
+        for (String lib : REQUIRED_LIBS) {
+            File path = new File(nativeLibraryDir, lib);
+            Log.i(TAG, "Loading " + path);
+            System.load(path.getAbsolutePath());
+        }
+
+        sLoaded = true;
+    }
+
+    public native int create(NativeDriverListener nativeDriverListener, String firmwareDirectory, boolean forceCpuEncoding);
+
+    public native long createImageReader(long encoder, DisplayMode displayMode, boolean z, boolean z2);
+
+    public native void destroy();
+
+    public native void destroyImageReader(long imageReaderHandle);
+
+    public native Surface getImageReaderSurface(long imageReaderHandle);
+
+    public native boolean isValid();
+
+    public native void log(String tag, int priority, String message);
+
+    public native void notifyEvent(int eventCode);
+
+    public native int postFrame(long encoder, ByteBuffer byteBuffer);
+
+    public native boolean receiveDdcCiData(long encoder, byte[] data, int length);
+
+    public native boolean sendDdcCiData(long encoder, byte[] data, int length);
+
+    public native void setMode(long encoder, DisplayMode displayMode, int rowStride, int format);
+
+    public native void setProtection(long encoder, boolean protectedContent);
+
+    public native int usbDeviceAttached(String deviceName, int fd, byte[] descriptors, int descriptorLength);
+
+    public native void usbDeviceDetached(String deviceName);
+}

--- a/app/src/main/java/com/displaylink/manager/NativeDriverListener.java
+++ b/app/src/main/java/com/displaylink/manager/NativeDriverListener.java
@@ -1,0 +1,53 @@
+package com.displaylink.manager;
+
+import android.util.Log;
+
+import androidx.annotation.Keep;
+
+import com.displaylink.manager.display.MonitorInfo;
+import com.termux.x11.displaylink.DisplayLinkBridge;
+
+@Keep
+public class NativeDriverListener {
+    private static final String TAG = "DisplayLinkListener";
+
+    @Keep
+    public void onDisplayConnected(long encoder) {
+        DisplayLinkBridge.writeMarker(DisplayLinkBridge.getInstance().getAppContextForDebug(),
+                "listener.onDisplayConnected encoder=0x" + Long.toHexString(encoder));
+        Log.i(TAG, "onDisplayConnected encoder=0x" + Long.toHexString(encoder));
+        DisplayLinkBridge.getInstance().onDisplayConnected(encoder);
+    }
+
+    @Keep
+    public void onDisplayDisconnected(long encoder) {
+        DisplayLinkBridge.writeMarker(DisplayLinkBridge.getInstance().getAppContextForDebug(),
+                "listener.onDisplayDisconnected encoder=0x" + Long.toHexString(encoder));
+        Log.i(TAG, "onDisplayDisconnected encoder=0x" + Long.toHexString(encoder));
+        DisplayLinkBridge.getInstance().onDisplayDisconnected(encoder);
+    }
+
+    @Keep
+    public void onError(int code) {
+        DisplayLinkBridge.writeMarker(DisplayLinkBridge.getInstance().getAppContextForDebug(),
+                "listener.onError code=" + code);
+        Log.e(TAG, "onError code=" + code);
+    }
+
+    @Keep
+    public void onFirmwareUpdateInfo(boolean started) {
+        DisplayLinkBridge.writeMarker(DisplayLinkBridge.getInstance().getAppContextForDebug(),
+                "listener.onFirmwareUpdateInfo started=" + started);
+        Log.i(TAG, "onFirmwareUpdateInfo started=" + started);
+    }
+
+    @Keep
+    public void onUpdateMonitorInfo(long encoder, MonitorInfo monitorInfo) {
+        DisplayLinkBridge.writeMarker(DisplayLinkBridge.getInstance().getAppContextForDebug(),
+                "listener.onUpdateMonitorInfo encoder=0x" + Long.toHexString(encoder)
+                        + " modeCount=" + (monitorInfo == null || monitorInfo.a == null ? 0 : monitorInfo.a.length));
+        Log.i(TAG, "onUpdateMonitorInfo encoder=0x" + Long.toHexString(encoder) + " modeCount="
+                + (monitorInfo == null || monitorInfo.a == null ? 0 : monitorInfo.a.length));
+        DisplayLinkBridge.getInstance().onMonitorInfo(encoder, monitorInfo);
+    }
+}

--- a/app/src/main/java/com/displaylink/manager/display/DisplayMode.java
+++ b/app/src/main/java/com/displaylink/manager/display/DisplayMode.java
@@ -1,0 +1,21 @@
+package com.displaylink.manager.display;
+
+import androidx.annotation.Keep;
+
+@Keep
+public class DisplayMode {
+    public final int width;
+    public final int height;
+    public final int refreshRate;
+
+    public DisplayMode(int width, int height, int refreshRate) {
+        this.width = width;
+        this.height = height;
+        this.refreshRate = refreshRate;
+    }
+
+    @Override
+    public String toString() {
+        return "(" + width + "x" + height + " @ " + refreshRate + "Hz)";
+    }
+}

--- a/app/src/main/java/com/displaylink/manager/display/MonitorInfo.java
+++ b/app/src/main/java/com/displaylink/manager/display/MonitorInfo.java
@@ -1,0 +1,30 @@
+package com.displaylink.manager.display;
+
+import androidx.annotation.Keep;
+
+@Keep
+public class MonitorInfo {
+    public final DisplayMode[] a;
+    public final String b;
+    public final String c;
+    public final String d;
+    public final int e;
+    public final int f;
+    public final boolean g;
+    public final boolean h;
+    public final boolean i;
+
+    public MonitorInfo(DisplayMode[] modes, String monitorName, String serialNumber, String viewerId,
+                       int physicalWidthCm, int physicalHeightCm,
+                       boolean supportsGpuEncoding, boolean isProtected, boolean supportsBasicAudio) {
+        this.a = modes;
+        this.b = monitorName;
+        this.c = serialNumber;
+        this.d = viewerId;
+        this.e = physicalWidthCm;
+        this.f = physicalHeightCm;
+        this.g = supportsGpuEncoding;
+        this.h = isProtected;
+        this.i = supportsBasicAudio;
+    }
+}

--- a/app/src/main/java/com/termux/x11/LorieView.java
+++ b/app/src/main/java/com/termux/x11/LorieView.java
@@ -839,6 +839,7 @@ public class LorieView extends SurfaceView implements InputStub {
 
     @FastNative private native void nativeInit();
     @FastNative private native void surfaceChanged(Surface surface);
+    @FastNative public native void requestRender();
     @FastNative private native void setFiltering(int filtering);
     @FastNative static native void connect(int fd);
     @CriticalNative static native boolean connected();

--- a/app/src/main/java/com/termux/x11/displaylink/DisplayLinkBridge.java
+++ b/app/src/main/java/com/termux/x11/displaylink/DisplayLinkBridge.java
@@ -1,0 +1,1371 @@
+package com.termux.x11.displaylink;
+
+import static android.app.PendingIntent.FLAG_IMMUTABLE;
+import static android.app.PendingIntent.FLAG_MUTABLE;
+import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
+import static android.os.Build.VERSION.SDK_INT;
+
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+import android.content.res.AssetManager;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbManager;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.annotation.Keep;
+import androidx.annotation.Nullable;
+
+import com.displaylink.manager.NativeDriver;
+import com.displaylink.manager.NativeDriverListener;
+import com.displaylink.manager.display.DisplayMode;
+import com.displaylink.manager.display.MonitorInfo;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.IntBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Keep
+public final class DisplayLinkBridge {
+    private static final String TAG = "DisplayLinkBridge";
+    private static final String DISPLAYLINK_PACKAGE = "com.displaylink.presenter";
+    private static final String ACTION_USB_PERMISSION = "com.displaylink.ACTION_USB_PERMISSION";
+    private static final String ACTION_USB_DEVICE_ATTACHED = "com.displaylink.ACTION_USB_DEVICE_ATTACHED";
+    private static final String ACTION_DETECT_DEVICES = "com.displaylink.ACTION_DETECT_DEVICES";
+    private static final int DISPLAYLINK_VENDOR_ID = 0x17e9;
+    private static final String MARKER_FILE_NAME = "displaylink-bridge.log";
+    private static final int EVENT_SCREEN_OFF = 0;
+    private static final int EVENT_SCREEN_ON = 1;
+    private static final int MAX_ATTACH_RETRIES = 2;
+    private static final int MAX_DRIVER_RESTARTS = 2;
+    private static final int INITIAL_FRAME_REPLAY_COUNT = 0;
+    private static final int INITIAL_FRAME_REPLAY_DELAY_MS = 80;
+
+    private static final DisplayLinkBridge INSTANCE = new DisplayLinkBridge();
+
+    private final Object lock = new Object();
+    private final Map<String, UsbDeviceConnection> connections = new ConcurrentHashMap<>();
+    private final Map<String, Integer> attachRetryCounts = new ConcurrentHashMap<>();
+    private final Set<String> pendingPermissionDevices = new HashSet<>();
+    private final Set<String> deniedPermissionDevices = new HashSet<>();
+    private final Set<String> attachingDevices = new HashSet<>();
+    private final BroadcastReceiver usbReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String action = intent.getAction();
+            UsbDevice device = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
+            Context markerContext = appContext != null ? appContext : context;
+            String deviceName = device != null ? device.getDeviceName() : "null";
+            writeMarker(markerContext, "bridge.usbReceiver.onReceive action=" + action + " device=" + deviceName);
+
+            if (ACTION_USB_PERMISSION.equals(action)) {
+                boolean granted = intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false);
+                writeMarker(markerContext, "bridge.usbReceiver.permission device=" + deviceName + " granted=" + granted);
+                Log.i(TAG, "USB permission result name=" + deviceName + " granted=" + granted);
+                handlePermissionResult(device, granted);
+                return;
+            }
+
+            if (ACTION_DETECT_DEVICES.equals(action)) {
+                writeMarker(markerContext, "bridge.usbReceiver.detect_devices");
+                scheduleProbe("detect_devices", 0);
+                return;
+            }
+
+            if (device == null || !isDisplayLinkDevice(device)) {
+                return;
+            }
+
+            if (UsbManager.ACTION_USB_DEVICE_ATTACHED.equals(action)
+                    || ACTION_USB_DEVICE_ATTACHED.equals(action)) {
+                writeMarker(markerContext, "bridge.usbReceiver.attached name=" + device.getDeviceName());
+                Log.i(TAG, "USB attached " + device.getDeviceName());
+                handleDeviceAttached(device);
+                return;
+            }
+
+            if (UsbManager.ACTION_USB_DEVICE_DETACHED.equals(action)) {
+                writeMarker(markerContext, "bridge.usbReceiver.detached name=" + device.getDeviceName());
+                Log.i(TAG, "USB detached " + device.getDeviceName());
+                handleDeviceDetached(device);
+            }
+        }
+    };
+
+    private Context appContext;
+    private UsbManager usbManager;
+    private NativeDriver nativeDriver;
+    private boolean started;
+    private boolean starting;
+    private long activeEncoder;
+    private int lastWidth;
+    private int lastHeight;
+    private int lastRowStride;
+    private int framePostCount;
+    private final ByteBuffer[] frameBuffers = new ByteBuffer[2];
+    private int retainedFrameBufferIndex = -1;
+    @Nullable private ByteBuffer clearFrameTemplate;
+    @Nullable private ByteBuffer pendingFrameBuffer;
+    private int pendingFrameWidth;
+    private int pendingFrameHeight;
+    private int pendingFrameRowStride;
+    private boolean replayScheduled;
+    private boolean driverRestartScheduled;
+    private int driverRestartCount;
+    @Nullable private MonitorInfo lastMonitorInfo;
+    @Nullable private String outstandingPermissionDeviceName;
+    private boolean permissionRequestOutstanding;
+
+    private DisplayLinkBridge() {
+    }
+
+    public static DisplayLinkBridge getInstance() {
+        return INSTANCE;
+    }
+
+    @Nullable
+    public Context getAppContextForDebug() {
+        return appContext;
+    }
+
+    public static void writeMarker(Context context, String message) {
+        if (context == null || message == null) {
+            return;
+        }
+
+        File marker = new File(context.getCacheDir(), MARKER_FILE_NAME);
+        String line = System.currentTimeMillis() + " " + message + "\n";
+        try (FileOutputStream out = new FileOutputStream(marker, true)) {
+            out.write(line.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+        } catch (IOException e) {
+            Log.w(TAG, "Failed to write marker", e);
+        }
+    }
+
+    public void start(Context context) {
+        writeMarker(context, "bridge.start.enter context=" + context);
+        if (context == null) {
+            Log.w(TAG, "start() skipped because context is null");
+            return;
+        }
+
+        synchronized (lock) {
+            if (started || starting) {
+                Log.i(TAG, "start() ignored started=" + started + " starting=" + starting);
+                return;
+            }
+
+            starting = true;
+        }
+
+        Context resolvedContext = context.getApplicationContext();
+        if (resolvedContext == null) {
+            resolvedContext = context;
+        }
+        if (resolvedContext == null) {
+            synchronized (lock) {
+                starting = false;
+            }
+            writeMarker(context, "bridge.start.skip application_context_unavailable");
+            Log.w(TAG, "start() skipped because application context is unavailable");
+            return;
+        }
+        final Context appContext = resolvedContext;
+        writeMarker(appContext, "bridge.start.schedule_init_thread");
+        Log.i(TAG, "start() scheduling init thread");
+        Thread initThread = new Thread(() -> startInternal(appContext), "DisplayLinkBridgeInit");
+        initThread.setDaemon(true);
+        initThread.start();
+    }
+
+    private void startInternal(Context context) {
+        boolean ready = false;
+        NativeDriver createdDriver = null;
+
+        writeMarker(context, "bridge.startInternal.begin context=" + context);
+        Log.i(TAG, "startInternal() begin");
+
+        if (context == null) {
+            synchronized (lock) {
+                starting = false;
+            }
+            writeMarker(appContext, "bridge.startInternal.abort null_context");
+            Log.w(TAG, "startInternal() aborted because context is null");
+            return;
+        }
+
+        synchronized (lock) {
+            if (started) {
+                writeMarker(context, "bridge.startInternal.already_started");
+                Log.i(TAG, "startInternal() exiting because already started");
+                starting = false;
+                return;
+            }
+
+            appContext = context;
+            writeMarker(appContext, "bridge.startInternal.set_app_context");
+            usbManager = (UsbManager) appContext.getSystemService(Context.USB_SERVICE);
+            if (usbManager == null) {
+                writeMarker(appContext, "bridge.startInternal.usb_manager_unavailable");
+                Log.e(TAG, "UsbManager unavailable");
+                starting = false;
+                return;
+            }
+
+            try {
+                writeMarker(appContext, "bridge.startInternal.ensureLoaded.begin");
+                Log.i(TAG, "Calling NativeDriver.ensureLoaded()");
+                NativeDriver.ensureLoaded(appContext);
+                writeMarker(appContext, "bridge.startInternal.ensureLoaded.done");
+                Log.i(TAG, "NativeDriver.ensureLoaded() finished");
+                File firmwareDir = prepareFirmwareDirectory(appContext);
+                writeMarker(appContext, "bridge.startInternal.prepareFirmware.done dir=" + firmwareDir);
+                nativeDriver = new NativeDriver();
+                int rc = nativeDriver.create(new NativeDriverListener(), firmwareDir.getAbsolutePath(), false);
+                writeMarker(appContext, "bridge.startInternal.nativeCreate rc=" + rc);
+                Log.i(TAG, "NativeDriver.create rc=" + rc + " firmwareDir=" + firmwareDir);
+                if (rc != 0 || !nativeDriver.isValid()) {
+                    writeMarker(appContext, "bridge.startInternal.native_invalid");
+                    Log.e(TAG, "DisplayLink native driver did not become valid");
+                    nativeDriver = null;
+                    starting = false;
+                    return;
+                }
+
+                createdDriver = nativeDriver;
+            } catch (Throwable e) {
+                writeMarker(appContext, "bridge.startInternal.exception " + e.getClass().getName() + ":" + e.getMessage());
+                Log.e(TAG, "Failed to initialise DisplayLink driver", e);
+                nativeDriver = null;
+                starting = false;
+                return;
+            }
+
+            registerUsbReceiver(appContext);
+            writeMarker(appContext, "bridge.startInternal.receiver_registered");
+            started = true;
+            starting = false;
+            ready = true;
+        }
+
+        if (ready) {
+            notifyDriverEvent(createdDriver, appContext, EVENT_SCREEN_ON, "startInternal");
+            writeMarker(appContext, "bridge.startInternal.probe_devices");
+            Log.i(TAG, "startInternal() probing attached USB devices");
+            probeAttachedDevices();
+        }
+    }
+
+    public void stop() {
+        Context context;
+        NativeDriver driver;
+        List<Map.Entry<String, UsbDeviceConnection>> openConnections;
+        synchronized (lock) {
+            if (!started) {
+                return;
+            }
+
+            context = appContext;
+            driver = nativeDriver;
+            openConnections = new ArrayList<>(connections.entrySet());
+            connections.clear();
+            attachRetryCounts.clear();
+            nativeDriver = null;
+            activeEncoder = 0;
+            lastMonitorInfo = null;
+            lastWidth = 0;
+            lastHeight = 0;
+            lastRowStride = 0;
+            framePostCount = 0;
+            clearFrameBuffersLocked();
+            replayScheduled = false;
+            clearPendingFrameLocked();
+            pendingPermissionDevices.clear();
+            deniedPermissionDevices.clear();
+            attachingDevices.clear();
+            outstandingPermissionDeviceName = null;
+            permissionRequestOutstanding = false;
+            driverRestartScheduled = false;
+            driverRestartCount = 0;
+            started = false;
+            starting = false;
+
+            try {
+                if (context != null) {
+                    context.unregisterReceiver(usbReceiver);
+                }
+            } catch (IllegalArgumentException e) {
+                Log.w(TAG, "Receiver already unregistered", e);
+            }
+        }
+
+        for (Map.Entry<String, UsbDeviceConnection> entry : openConnections) {
+            try {
+                if (driver != null) {
+                    driver.usbDeviceDetached(entry.getKey());
+                }
+            } catch (Throwable e) {
+                Log.w(TAG, "usbDeviceDetached failed for " + entry.getKey(), e);
+            }
+            entry.getValue().close();
+        }
+
+        if (driver != null) {
+            try {
+                notifyDriverEvent(driver, context, EVENT_SCREEN_OFF, "stop");
+                driver.destroy();
+            } catch (Throwable e) {
+                Log.w(TAG, "NativeDriver.destroy failed", e);
+            }
+        }
+    }
+
+    @Keep
+    public static boolean pushFrame(ByteBuffer buffer, int width, int height, int rowStride) {
+        Context context = INSTANCE.appContext;
+        if (context != null && INSTANCE.framePostCount == 0) {
+            writeMarker(context, "bridge.pushFrame.entry width=" + width + " height=" + height + " rowStride=" + rowStride);
+        }
+        return INSTANCE.pushFrameInternal(buffer, width, height, rowStride);
+    }
+
+    @Keep
+    public static boolean isCaptureReady() {
+        return INSTANCE.isCaptureReadyInternal();
+    }
+
+    @Keep
+    public static int getCaptureWidth() {
+        return INSTANCE.getCaptureWidthInternal();
+    }
+
+    @Keep
+    public static int getCaptureHeight() {
+        return INSTANCE.getCaptureHeightInternal();
+    }
+
+    private boolean isCaptureReadyInternal() {
+        synchronized (lock) {
+            return started && nativeDriver != null && activeEncoder != 0;
+        }
+    }
+
+    private int getCaptureWidthInternal() {
+        synchronized (lock) {
+            DisplayMode preferred = preferredModeOf(lastMonitorInfo);
+            return preferred != null ? preferred.width : 0;
+        }
+    }
+
+    private int getCaptureHeightInternal() {
+        synchronized (lock) {
+            DisplayMode preferred = preferredModeOf(lastMonitorInfo);
+            return preferred != null ? preferred.height : 0;
+        }
+    }
+
+    public void onDisplayConnected(long encoder) {
+        synchronized (lock) {
+            activeEncoder = encoder;
+            lastWidth = 0;
+            lastHeight = 0;
+            lastRowStride = 0;
+            clearFrameBuffersLocked();
+            attachRetryCounts.clear();
+            driverRestartScheduled = false;
+            driverRestartCount = 0;
+            if (nativeDriver != null) {
+                try {
+                    nativeDriver.setProtection(encoder, false);
+                    writeMarker(appContext, "bridge.onDisplayConnected.setProtection encoder=0x" + Long.toHexString(encoder) + " protected=false");
+                } catch (Throwable e) {
+                    writeMarker(appContext, "bridge.onDisplayConnected.setProtection_failed encoder=0x" + Long.toHexString(encoder)
+                            + " error=" + e.getClass().getSimpleName());
+                    Log.w(TAG, "setProtection(false) failed for encoder=0x" + Long.toHexString(encoder), e);
+                }
+            }
+            writeMarker(appContext, "bridge.onDisplayConnected encoder=0x" + Long.toHexString(encoder));
+            Log.i(TAG, "Active encoder set to 0x" + Long.toHexString(encoder));
+        }
+
+        flushPendingFrame("display_connected");
+    }
+
+    public void onDisplayDisconnected(long encoder) {
+        synchronized (lock) {
+            if (activeEncoder == encoder) {
+                activeEncoder = 0;
+                lastWidth = 0;
+                lastHeight = 0;
+                lastRowStride = 0;
+                lastMonitorInfo = null;
+            }
+            writeMarker(appContext, "bridge.onDisplayDisconnected encoder=0x" + Long.toHexString(encoder));
+        }
+    }
+
+    public void onMonitorInfo(long encoder, @Nullable MonitorInfo monitorInfo) {
+        synchronized (lock) {
+            boolean encoderChanged = activeEncoder != 0 && activeEncoder != encoder;
+            boolean modeChanged = !samePreferredMode(lastMonitorInfo, monitorInfo);
+
+            if (activeEncoder == 0 || activeEncoder == encoder) {
+                activeEncoder = encoder;
+                lastMonitorInfo = monitorInfo;
+                if (encoderChanged || modeChanged) {
+                    lastWidth = 0;
+                    lastHeight = 0;
+                    lastRowStride = 0;
+                    clearFrameBuffersLocked();
+                }
+            }
+            int modeCount = monitorInfo == null || monitorInfo.a == null ? 0 : monitorInfo.a.length;
+            writeMarker(appContext, "bridge.onMonitorInfo encoder=0x" + Long.toHexString(encoder) + " modeCount=" + modeCount);
+            if (modeCount > 0) {
+                DisplayMode preferred = monitorInfo.a[0];
+                writeMarker(appContext, "bridge.onMonitorInfo.preferred encoder=0x" + Long.toHexString(encoder)
+                        + " width=" + preferred.width + " height=" + preferred.height
+                        + " refresh=" + preferred.refreshRate);
+            }
+        }
+
+        flushPendingFrame("monitor_info");
+    }
+
+    private boolean pushFrameInternal(ByteBuffer buffer, int width, int height, int rowStride) {
+        boolean deferPendingFrame = false;
+
+        synchronized (lock) {
+            if (!started || nativeDriver == null || buffer == null) {
+                writeMarker(appContext, "bridge.pushFrame.skip started=" + started + " nativeDriver=" + (nativeDriver != null)
+                        + " activeEncoder=0x" + Long.toHexString(activeEncoder) + " buffer=" + (buffer != null));
+                return false;
+            }
+
+            if (activeEncoder == 0) {
+                deferPendingFrame = true;
+            } else {
+                DisplayMode mode = chooseMode(width, height);
+                if (mode == null) {
+                    return false;
+                }
+
+                ByteBuffer postBuffer = preparePostBufferLocked(buffer, width, height, rowStride, mode);
+                if (postBuffer == null) {
+                    writeMarker(appContext, "bridge.pushFrame.prepare_failed encoder=0x" + Long.toHexString(activeEncoder));
+                    return false;
+                }
+
+                int targetRowStride = mode.width * 4;
+
+                if (lastWidth != mode.width || lastHeight != mode.height || lastRowStride != targetRowStride) {
+                    writeMarker(appContext, "bridge.pushFrame.setMode encoder=0x" + Long.toHexString(activeEncoder)
+                            + " width=" + mode.width + " height=" + mode.height + " rowStride=" + targetRowStride);
+                    Log.i(TAG, "Setting mode encoder=0x" + Long.toHexString(activeEncoder) + " mode=" + mode
+                            + " rowStride=" + targetRowStride + " source=" + width + "x" + height);
+                    nativeDriver.setMode(activeEncoder, mode, targetRowStride, 1);
+                    lastWidth = mode.width;
+                    lastHeight = mode.height;
+                    lastRowStride = targetRowStride;
+                }
+
+                int rc = nativeDriver.postFrame(activeEncoder, postBuffer);
+                if (rc < 0) {
+                    writeMarker(appContext, "bridge.pushFrame.post_failed rc=" + rc + " encoder=0x"
+                            + Long.toHexString(activeEncoder));
+                    Log.e(TAG, "postFrame failed rc=" + rc + " encoder=0x" + Long.toHexString(activeEncoder));
+                    return false;
+                }
+
+                if (rc != 1 && rc != -2) {
+                    retainedFrameBufferIndex = indexOfBuffer(postBuffer);
+                }
+
+                framePostCount++;
+                if (framePostCount <= 3 || framePostCount % 60 == 0) {
+                    writeMarker(appContext, "bridge.pushFrame.post_ok count=" + framePostCount
+                            + " encoder=0x" + Long.toHexString(activeEncoder)
+                            + " width=" + mode.width + " height=" + mode.height + " rowStride=" + targetRowStride
+                            + " rc=" + rc + " source=" + width + "x" + height);
+                }
+
+                if (framePostCount == 1 && INITIAL_FRAME_REPLAY_COUNT > 0 && !replayScheduled) {
+                    replayScheduled = true;
+                    scheduleFrameReplay(activeEncoder, INITIAL_FRAME_REPLAY_COUNT, INITIAL_FRAME_REPLAY_DELAY_MS);
+                }
+
+                return true;
+            }
+        }
+
+        if (deferPendingFrame) {
+            ByteBuffer copiedBuffer = copyFrameBuffer(buffer, rowStride * height);
+            synchronized (lock) {
+                if (!started || nativeDriver == null) {
+                    return false;
+                }
+
+                if (activeEncoder == 0) {
+                    pendingFrameBuffer = copiedBuffer;
+                    pendingFrameWidth = width;
+                    pendingFrameHeight = height;
+                    pendingFrameRowStride = rowStride;
+                    writeMarker(appContext, "bridge.pushFrame.defer width=" + width + " height=" + height
+                            + " rowStride=" + rowStride);
+                    return false;
+                }
+            }
+
+            return pushFrameInternal(copiedBuffer, width, height, rowStride);
+        }
+
+        return false;
+    }
+
+    private boolean samePreferredMode(@Nullable MonitorInfo left, @Nullable MonitorInfo right) {
+        DisplayMode leftPreferred = preferredModeOf(left);
+        DisplayMode rightPreferred = preferredModeOf(right);
+
+        if (leftPreferred == null || rightPreferred == null) {
+            return leftPreferred == rightPreferred;
+        }
+
+        return leftPreferred.width == rightPreferred.width
+                && leftPreferred.height == rightPreferred.height
+                && leftPreferred.refreshRate == rightPreferred.refreshRate;
+    }
+
+    @Nullable
+    private DisplayMode preferredModeOf(@Nullable MonitorInfo info) {
+        if (info == null || info.a == null || info.a.length == 0) {
+            return null;
+        }
+        return info.a[0];
+    }
+
+    @Nullable
+    private DisplayMode chooseMode(int width, int height) {
+        MonitorInfo info = lastMonitorInfo;
+        if (info != null && info.a != null && info.a.length > 0) {
+            DisplayMode preferred = info.a[0];
+            if (preferred.width != width || preferred.height != height) {
+                Log.w(TAG, "Source size " + width + "x" + height + " differs from preferred mode " + preferred);
+            }
+            return preferred;
+        }
+
+        return new DisplayMode(width, height, 60);
+    }
+
+    @Nullable
+    private ByteBuffer preparePostBufferLocked(ByteBuffer source, int sourceWidth, int sourceHeight, int sourceRowStride,
+                                               DisplayMode mode) {
+        int targetWidth = mode.width;
+        int targetHeight = mode.height;
+        int targetRowStride = targetWidth * 4;
+        int targetSize = targetRowStride * targetHeight;
+
+        int bufferIndex = retainedFrameBufferIndex == 0 ? 1 : 0;
+        ByteBuffer target = frameBuffers[bufferIndex];
+        if (target == null || target.capacity() != targetSize) {
+            target = ByteBuffer.allocateDirect(targetSize);
+            frameBuffers[bufferIndex] = target;
+        }
+
+        if (sourceWidth == targetWidth && sourceHeight == targetHeight) {
+            copyFrame(source, sourceRowStride, target, targetRowStride, sourceWidth, sourceHeight);
+        } else {
+            clearBuffer(target, targetSize);
+            blitScaledCentered(source, sourceWidth, sourceHeight, sourceRowStride, target, targetWidth, targetHeight, targetRowStride);
+        }
+
+        target.position(0);
+        target.limit(targetSize);
+        return target;
+    }
+
+    private void copyFrame(ByteBuffer source, int sourceRowStride, ByteBuffer target, int targetRowStride, int width, int height) {
+        ByteBuffer sourceRow = source.duplicate();
+        ByteBuffer targetRow = target.duplicate();
+        int rowBytes = width * 4;
+
+        for (int y = 0; y < height; y++) {
+            int sourceOffset = (height - 1 - y) * sourceRowStride;
+            int targetOffset = y * targetRowStride;
+
+            sourceRow.position(sourceOffset);
+            sourceRow.limit(sourceOffset + rowBytes);
+            targetRow.position(targetOffset);
+            targetRow.put(sourceRow);
+        }
+    }
+
+    private void blitScaledCentered(ByteBuffer source, int sourceWidth, int sourceHeight, int sourceRowStride,
+                                    ByteBuffer target, int targetWidth, int targetHeight, int targetRowStride) {
+        float scale = Math.min((float) targetWidth / (float) sourceWidth, (float) targetHeight / (float) sourceHeight);
+        int scaledWidth = Math.max(1, Math.round(sourceWidth * scale));
+        int scaledHeight = Math.max(1, Math.round(sourceHeight * scale));
+        int offsetX = (targetWidth - scaledWidth) / 2;
+        int offsetY = (targetHeight - scaledHeight) / 2;
+        int sourceStridePixels = sourceRowStride / 4;
+        int targetStridePixels = targetRowStride / 4;
+        IntBuffer sourcePixels = source.duplicate().asIntBuffer();
+        IntBuffer targetPixels = target.duplicate().asIntBuffer();
+
+        for (int y = 0; y < scaledHeight; y++) {
+            int sourceY = y * sourceHeight / scaledHeight;
+            int flippedSourceY = sourceHeight - 1 - sourceY;
+            int sourceRowBase = flippedSourceY * sourceStridePixels;
+            int targetRowBase = (offsetY + y) * targetStridePixels + offsetX;
+            for (int x = 0; x < scaledWidth; x++) {
+                int sourceX = x * sourceWidth / scaledWidth;
+                targetPixels.put(targetRowBase + x, sourcePixels.get(sourceRowBase + sourceX));
+            }
+        }
+    }
+
+    private void clearBuffer(ByteBuffer buffer, int size) {
+        if (clearFrameTemplate == null || clearFrameTemplate.capacity() != size) {
+            clearFrameTemplate = ByteBuffer.allocateDirect(size);
+        }
+
+        ByteBuffer blank = clearFrameTemplate.duplicate();
+        blank.position(0);
+        blank.limit(size);
+        buffer.position(0);
+        buffer.limit(size);
+        buffer.put(blank);
+        buffer.position(0);
+        buffer.limit(size);
+    }
+
+    private int indexOfBuffer(ByteBuffer buffer) {
+        for (int i = 0; i < frameBuffers.length; i++) {
+            if (frameBuffers[i] == buffer) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void clearFrameBuffersLocked() {
+        Arrays.fill(frameBuffers, null);
+        retainedFrameBufferIndex = -1;
+        replayScheduled = false;
+        clearFrameTemplate = null;
+    }
+
+    private void clearPendingFrameLocked() {
+        pendingFrameBuffer = null;
+        pendingFrameWidth = 0;
+        pendingFrameHeight = 0;
+        pendingFrameRowStride = 0;
+    }
+
+    private ByteBuffer copyFrameBuffer(ByteBuffer buffer, int size) {
+        ByteBuffer source = buffer.duplicate();
+        ByteBuffer copy = ByteBuffer.allocateDirect(size);
+        source.position(0);
+        source.limit(size);
+        copy.put(source);
+        copy.position(0);
+        copy.limit(size);
+        return copy;
+    }
+
+    private void flushPendingFrame(String reason) {
+        ByteBuffer pending;
+        int width;
+        int height;
+        int rowStride;
+
+        synchronized (lock) {
+            if (!started || nativeDriver == null || activeEncoder == 0 || pendingFrameBuffer == null) {
+                return;
+            }
+
+            pending = pendingFrameBuffer.duplicate();
+            pending.position(0);
+            pending.limit(pendingFrameBuffer.limit());
+            width = pendingFrameWidth;
+            height = pendingFrameHeight;
+            rowStride = pendingFrameRowStride;
+            clearPendingFrameLocked();
+        }
+
+        writeMarker(appContext, "bridge.pendingFrame.flush reason=" + reason + " width=" + width
+                + " height=" + height + " rowStride=" + rowStride);
+        pushFrameInternal(pending, width, height, rowStride);
+    }
+
+    private void scheduleFrameReplay(long encoder, int repeats, long delayMs) {
+        Thread replayThread = new Thread(() -> {
+            for (int i = 0; i < repeats; i++) {
+                try {
+                    Thread.sleep(delayMs);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+
+                synchronized (lock) {
+                    if (!started || nativeDriver == null || activeEncoder != encoder || retainedFrameBufferIndex < 0) {
+                        replayScheduled = false;
+                        return;
+                    }
+
+                    ByteBuffer retained = frameBuffers[retainedFrameBufferIndex];
+                    if (retained == null) {
+                        replayScheduled = false;
+                        return;
+                    }
+
+                    int rc = nativeDriver.postFrame(activeEncoder, retained);
+                    writeMarker(appContext, "bridge.pushFrame.replay index=" + (i + 1) + " rc=" + rc
+                            + " encoder=0x" + Long.toHexString(activeEncoder));
+                }
+            }
+
+            synchronized (lock) {
+                replayScheduled = false;
+            }
+        }, "DisplayLinkFrameReplay");
+        replayThread.setDaemon(true);
+        replayThread.start();
+    }
+
+    private void registerUsbReceiver(Context context) {
+        IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
+        filter.addAction(ACTION_USB_DEVICE_ATTACHED);
+        filter.addAction(ACTION_DETECT_DEVICES);
+        filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
+        filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
+        if (SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(usbReceiver, filter, Context.RECEIVER_EXPORTED);
+        } else {
+            context.registerReceiver(usbReceiver, filter);
+        }
+    }
+
+    private void probeAttachedDevices() {
+        synchronized (lock) {
+            if (!started || usbManager == null) {
+                return;
+            }
+        }
+
+        writeMarker(appContext, "bridge.probeAttachedDevices.enter");
+        List<UsbDevice> displayLinkDevices = new ArrayList<>();
+        List<UsbDevice> devicesToAttach = new ArrayList<>();
+        UsbDevice permissionRequest = null;
+        try {
+            HashMap<String, UsbDevice> devices = usbManager.getDeviceList();
+            writeMarker(appContext, "bridge.probeAttachedDevices.count=" + devices.size());
+            cleanupStaleConnections(devices);
+            for (UsbDevice device : devices.values()) {
+                writeMarker(appContext, "bridge.probeAttachedDevices.device name=" + device.getDeviceName()
+                        + " vid=0x" + Integer.toHexString(device.getVendorId())
+                        + " pid=0x" + Integer.toHexString(device.getProductId()));
+                if (isDisplayLinkDevice(device)) {
+                    displayLinkDevices.add(device);
+                    writeMarker(appContext, "bridge.probeAttachedDevices.displaylink_found name=" + device.getDeviceName());
+                }
+            }
+
+            synchronized (lock) {
+                pruneMissingDeviceStateLocked(displayLinkDevices);
+                for (UsbDevice device : displayLinkDevices) {
+                    String deviceName = device.getDeviceName();
+                    if (connections.containsKey(deviceName) || attachingDevices.contains(deviceName)) {
+                        continue;
+                    }
+
+                    if (usbManager.hasPermission(device)) {
+                        pendingPermissionDevices.remove(deviceName);
+                        deniedPermissionDevices.remove(deviceName);
+                        devicesToAttach.add(device);
+                        continue;
+                    }
+
+                    if (deniedPermissionDevices.contains(deviceName)) {
+                        continue;
+                    }
+
+                    pendingPermissionDevices.add(deviceName);
+                    if (!permissionRequestOutstanding && permissionRequest == null) {
+                        permissionRequestOutstanding = true;
+                        outstandingPermissionDeviceName = deviceName;
+                        permissionRequest = device;
+                    }
+                }
+            }
+        } catch (Throwable e) {
+            writeMarker(appContext, "bridge.probeAttachedDevices.exception " + e.getClass().getName() + ":" + e.getMessage());
+            Log.e(TAG, "probeAttachedDevices failed", e);
+            synchronized (lock) {
+                permissionRequestOutstanding = false;
+                outstandingPermissionDeviceName = null;
+            }
+            return;
+        }
+
+        if (permissionRequest != null) {
+            requestPermission(permissionRequest);
+        }
+
+        for (UsbDevice device : devicesToAttach) {
+            attachDevice(device);
+        }
+    }
+
+    private void requestPermission(UsbDevice device) {
+        writeMarker(appContext, "bridge.requestPermission name=" + device.getDeviceName()
+                + " hasPermission=" + usbManager.hasPermission(device));
+        Intent intent = new Intent(ACTION_USB_PERMISSION).setPackage(appContext.getPackageName());
+        int flags = FLAG_UPDATE_CURRENT;
+        if (SDK_INT >= Build.VERSION_CODES.S) {
+            flags |= FLAG_MUTABLE;
+        } else {
+            flags |= FLAG_IMMUTABLE;
+        }
+        writeMarker(appContext, "bridge.requestPermission.begin name=" + device.getDeviceName()
+                + " flags=0x" + Integer.toHexString(flags));
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(appContext, 0, intent, flags);
+        usbManager.requestPermission(device, pendingIntent);
+    }
+
+    private void handleDeviceAttached(UsbDevice device) {
+        synchronized (lock) {
+            deniedPermissionDevices.remove(device.getDeviceName());
+        }
+        scheduleProbe("usb_attached", 0);
+    }
+
+    private void handleDeviceDetached(UsbDevice device) {
+        synchronized (lock) {
+            String deviceName = device.getDeviceName();
+            pendingPermissionDevices.remove(deviceName);
+            deniedPermissionDevices.remove(deviceName);
+            attachingDevices.remove(deviceName);
+            if (deviceName.equals(outstandingPermissionDeviceName)) {
+                outstandingPermissionDeviceName = null;
+                permissionRequestOutstanding = false;
+            }
+        }
+        detachDevice(device.getDeviceName());
+        scheduleProbe("usb_detached", 0);
+    }
+
+    private void handlePermissionResult(@Nullable UsbDevice device, boolean granted) {
+        synchronized (lock) {
+            permissionRequestOutstanding = false;
+            outstandingPermissionDeviceName = null;
+            if (device != null) {
+                String deviceName = device.getDeviceName();
+                pendingPermissionDevices.remove(deviceName);
+                if (granted) {
+                    deniedPermissionDevices.remove(deviceName);
+                } else {
+                    deniedPermissionDevices.add(deviceName);
+                }
+            }
+        }
+        scheduleProbe(granted ? "permission_granted" : "permission_denied", 0);
+    }
+
+    private void pruneMissingDeviceStateLocked(List<UsbDevice> devices) {
+        Set<String> deviceNames = new HashSet<>();
+        for (UsbDevice device : devices) {
+            deviceNames.add(device.getDeviceName());
+        }
+
+        pendingPermissionDevices.retainAll(deviceNames);
+        deniedPermissionDevices.retainAll(deviceNames);
+        attachingDevices.retainAll(deviceNames);
+        if (outstandingPermissionDeviceName != null && !deviceNames.contains(outstandingPermissionDeviceName)) {
+            outstandingPermissionDeviceName = null;
+            permissionRequestOutstanding = false;
+        }
+    }
+
+    private void attachDevice(UsbDevice device) {
+        String deviceName = device.getDeviceName();
+        synchronized (lock) {
+            if (!started || nativeDriver == null) {
+                writeMarker(appContext, "bridge.attachDevice.skip started=" + started + " nativeDriver=" + nativeDriver);
+                return;
+            }
+
+            if (connections.containsKey(deviceName) || attachingDevices.contains(deviceName)) {
+                writeMarker(appContext, "bridge.attachDevice.skip existing name=" + deviceName);
+                return;
+            }
+
+            attachingDevices.add(deviceName);
+        }
+
+        UsbDeviceConnection connection = usbManager.openDevice(device);
+        if (connection == null) {
+            synchronized (lock) {
+                attachingDevices.remove(deviceName);
+            }
+            writeMarker(appContext, "bridge.attachDevice.open_failed name=" + deviceName);
+            Log.e(TAG, "Failed to open USB device " + deviceName);
+            return;
+        }
+
+        byte[] descriptors = connection.getRawDescriptors();
+        if (descriptors == null) {
+            descriptors = new byte[0];
+        }
+
+        int rc;
+        synchronized (lock) {
+            if (!started || nativeDriver == null) {
+                attachingDevices.remove(deviceName);
+                writeMarker(appContext, "bridge.attachDevice.abort_after_open started=" + started + " nativeDriver=" + nativeDriver);
+                connection.close();
+                return;
+            }
+            rc = nativeDriver.usbDeviceAttached(deviceName, connection.getFileDescriptor(), descriptors, descriptors.length);
+        }
+
+        writeMarker(appContext, "bridge.attachDevice.rc name=" + deviceName + " rc=" + rc + " descriptors=" + descriptors.length);
+        Log.i(TAG, "usbDeviceAttached rc=" + rc + " name=" + deviceName + " fd=" + connection.getFileDescriptor()
+                + " descriptors=" + descriptors.length);
+        if (rc != 0) {
+            synchronized (lock) {
+                attachingDevices.remove(deviceName);
+            }
+            connection.close();
+            return;
+        }
+
+        connections.put(deviceName, connection);
+        synchronized (lock) {
+            attachingDevices.remove(deviceName);
+            pendingPermissionDevices.remove(deviceName);
+            deniedPermissionDevices.remove(deviceName);
+        }
+        scheduleNotifyScreenOn("attach_success", 250);
+        scheduleNotifyScreenOn("attach_success_retry", 1500);
+        scheduleProbe("attach_success", 1000);
+        scheduleConnectedWatchdog(deviceName, 2500);
+    }
+
+    private void detachDevice(String deviceName) {
+        UsbDeviceConnection connection = connections.remove(deviceName);
+        NativeDriver driver;
+        synchronized (lock) {
+            attachingDevices.remove(deviceName);
+            pendingPermissionDevices.remove(deviceName);
+            driver = nativeDriver;
+        }
+        if (driver != null) {
+            try {
+                driver.usbDeviceDetached(deviceName);
+            } catch (Throwable e) {
+                Log.w(TAG, "usbDeviceDetached failed for " + deviceName, e);
+            }
+        }
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    private void scheduleProbe(String reason, long delayMs) {
+        Context context = appContext;
+        if (context == null) {
+            return;
+        }
+
+        writeMarker(context, "bridge.scheduleProbe reason=" + reason + " delayMs=" + delayMs);
+        Thread probeThread = new Thread(() -> {
+            try {
+                Thread.sleep(delayMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            probeAttachedDevices();
+        }, "DisplayLinkProbe");
+        probeThread.setDaemon(true);
+        probeThread.start();
+    }
+
+    private void scheduleNotifyScreenOn(String reason, long delayMs) {
+        Context context = appContext;
+        if (context == null) {
+            return;
+        }
+
+        writeMarker(context, "bridge.scheduleNotify reason=" + reason + " delayMs=" + delayMs);
+        Thread notifyThread = new Thread(() -> {
+            try {
+                Thread.sleep(delayMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+
+            synchronized (lock) {
+                NativeDriver driver = nativeDriver;
+                Context currentContext = appContext;
+                if (!started || driver == null) {
+                    return;
+                }
+
+                notifyDriverEvent(driver, currentContext, EVENT_SCREEN_ON, reason);
+            }
+        }, "DisplayLinkNotify");
+        notifyThread.setDaemon(true);
+        notifyThread.start();
+    }
+
+    private void scheduleConnectedWatchdog(String deviceName, long delayMs) {
+        Context context = appContext;
+        if (context == null) {
+            return;
+        }
+
+        writeMarker(context, "bridge.scheduleWatchdog name=" + deviceName + " delayMs=" + delayMs);
+        Thread watchdogThread = new Thread(() -> {
+            try {
+                Thread.sleep(delayMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+
+            synchronized (lock) {
+                if (!started || nativeDriver == null || activeEncoder != 0 || !connections.containsKey(deviceName)) {
+                    return;
+                }
+
+                int retryCount = attachRetryCounts.getOrDefault(deviceName, 0);
+                if (retryCount >= MAX_ATTACH_RETRIES) {
+                    if (driverRestartScheduled || driverRestartCount >= MAX_DRIVER_RESTARTS) {
+                        writeMarker(appContext, "bridge.watchdog.give_up name=" + deviceName + " retries=" + retryCount
+                                + " restartScheduled=" + driverRestartScheduled + " restartCount=" + driverRestartCount);
+                        return;
+                    }
+
+                    driverRestartScheduled = true;
+                    driverRestartCount++;
+                    writeMarker(appContext, "bridge.watchdog.global_reattach name=" + deviceName + " retries=" + retryCount
+                            + " restartCount=" + driverRestartCount);
+                    scheduleGlobalReattach("watchdog_" + deviceName, 100);
+                    return;
+                }
+
+                attachRetryCounts.put(deviceName, retryCount + 1);
+                writeMarker(appContext, "bridge.watchdog.reattach name=" + deviceName + " retry=" + (retryCount + 1));
+            }
+
+            forceReattach(deviceName);
+        }, "DisplayLinkWatchdog");
+        watchdogThread.setDaemon(true);
+        watchdogThread.start();
+    }
+
+    private void forceReattach(String deviceName) {
+        UsbDevice device = usbManager.getDeviceList().get(deviceName);
+        if (device == null) {
+            writeMarker(appContext, "bridge.forceReattach.missing name=" + deviceName);
+            return;
+        }
+
+        detachDevice(deviceName);
+        scheduleNotifyScreenOn("force_reattach", 150);
+        attachDevice(device);
+    }
+
+    public void restart(String reason) {
+        scheduleGlobalReattach(reason, 0);
+    }
+
+    private void scheduleGlobalReattach(String reason, long delayMs) {
+        Context context = appContext;
+        if (context == null) {
+            return;
+        }
+
+        writeMarker(context, "bridge.scheduleGlobalReattach reason=" + reason + " delayMs=" + delayMs);
+        Thread reattachThread = new Thread(() -> {
+            if (delayMs > 0) {
+                try {
+                    Thread.sleep(delayMs);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    synchronized (lock) {
+                        driverRestartScheduled = false;
+                    }
+                    return;
+                }
+            }
+
+            globalReattach(reason);
+        }, "DisplayLinkGlobalReattach");
+        reattachThread.setDaemon(true);
+        reattachThread.start();
+    }
+
+    private void globalReattach(String reason) {
+        Context context;
+        List<String> deviceNames;
+        synchronized (lock) {
+            context = appContext;
+            if (!started || nativeDriver == null || context == null) {
+                driverRestartScheduled = false;
+                return;
+            }
+
+            deviceNames = new ArrayList<>(connections.keySet());
+            attachRetryCounts.clear();
+        }
+
+        writeMarker(context, "bridge.globalReattach.begin reason=" + reason + " activeConnections=" + deviceNames.size());
+        for (String deviceName : deviceNames) {
+            writeMarker(context, "bridge.globalReattach.detach name=" + deviceName + " reason=" + reason);
+            detachDevice(deviceName);
+        }
+
+        synchronized (lock) {
+            driverRestartScheduled = false;
+        }
+
+        scheduleNotifyScreenOn("global_reattach_" + reason, 150);
+        scheduleProbe("global_reattach_" + reason, 250);
+        scheduleProbe("global_reattach_retry_" + reason, 1200);
+    }
+
+    private void scheduleDriverRestart(String reason, long delayMs) {
+        Context context = appContext;
+        if (context == null) {
+            return;
+        }
+
+        writeMarker(context, "bridge.scheduleDriverRestart reason=" + reason + " delayMs=" + delayMs);
+        Thread restartThread = new Thread(() -> {
+            if (delayMs > 0) {
+                try {
+                    Thread.sleep(delayMs);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    synchronized (lock) {
+                        driverRestartScheduled = false;
+                    }
+                    return;
+                }
+            }
+
+            restartDriver(reason);
+        }, "DisplayLinkDriverRestart");
+        restartThread.setDaemon(true);
+        restartThread.start();
+    }
+
+    private void restartDriver(String reason) {
+        Context context;
+        NativeDriver oldDriver;
+        List<Map.Entry<String, UsbDeviceConnection>> openConnections;
+        synchronized (lock) {
+            context = appContext;
+            if (!started || context == null) {
+                driverRestartScheduled = false;
+                return;
+            }
+            oldDriver = nativeDriver;
+            openConnections = new ArrayList<>(connections.entrySet());
+            connections.clear();
+            attachRetryCounts.clear();
+            activeEncoder = 0;
+            lastMonitorInfo = null;
+            lastWidth = 0;
+            lastHeight = 0;
+            lastRowStride = 0;
+            framePostCount = 0;
+            clearFrameBuffersLocked();
+            nativeDriver = null;
+        }
+
+        writeMarker(context, "bridge.restartDriver.begin reason=" + reason);
+
+        for (Map.Entry<String, UsbDeviceConnection> entry : openConnections) {
+            writeMarker(context, "bridge.restartDriver.detach name=" + entry.getKey());
+            try {
+                if (oldDriver != null) {
+                    oldDriver.usbDeviceDetached(entry.getKey());
+                    writeMarker(context, "bridge.restartDriver.detached name=" + entry.getKey());
+                }
+            } catch (Throwable e) {
+                writeMarker(context, "bridge.restartDriver.detach_failed name=" + entry.getKey() + " error="
+                        + e.getClass().getSimpleName());
+                Log.w(TAG, "usbDeviceDetached failed during restart for " + entry.getKey(), e);
+            }
+            entry.getValue().close();
+            writeMarker(context, "bridge.restartDriver.closed name=" + entry.getKey());
+        }
+
+        if (oldDriver != null) {
+            try {
+                writeMarker(context, "bridge.restartDriver.notify_off.begin reason=" + reason);
+                notifyDriverEvent(oldDriver, context, EVENT_SCREEN_OFF, "restart_" + reason);
+                writeMarker(context, "bridge.restartDriver.notify_off.done reason=" + reason);
+                writeMarker(context, "bridge.restartDriver.destroy.begin reason=" + reason);
+                oldDriver.destroy();
+                writeMarker(context, "bridge.restartDriver.destroy.done reason=" + reason);
+            } catch (Throwable e) {
+                writeMarker(context, "bridge.restartDriver.destroy_failed reason=" + reason + " error="
+                        + e.getClass().getSimpleName());
+                Log.w(TAG, "NativeDriver.destroy failed during restart", e);
+            }
+        }
+
+        try {
+            File firmwareDir = prepareFirmwareDirectory(context);
+            writeMarker(context, "bridge.restartDriver.prepareFirmware.done dir=" + firmwareDir);
+            NativeDriver replacement = new NativeDriver();
+            writeMarker(context, "bridge.restartDriver.nativeCreate.begin reason=" + reason);
+            int rc = replacement.create(new NativeDriverListener(), firmwareDir.getAbsolutePath(), false);
+            boolean restartReady = false;
+            Context restartContext = null;
+            synchronized (lock) {
+                if (!started) {
+                    driverRestartScheduled = false;
+                    try {
+                        replacement.destroy();
+                    } catch (Throwable e) {
+                        Log.w(TAG, "NativeDriver.destroy failed after late restart cancellation", e);
+                    }
+                    return;
+                }
+
+                nativeDriver = replacement;
+                writeMarker(appContext, "bridge.restartDriver.nativeCreate rc=" + rc + " reason=" + reason);
+                if (rc != 0 || !nativeDriver.isValid()) {
+                    writeMarker(appContext, "bridge.restartDriver.native_invalid reason=" + reason);
+                    try {
+                        nativeDriver.destroy();
+                    } catch (Throwable e) {
+                        Log.w(TAG, "NativeDriver.destroy failed after invalid restart", e);
+                    }
+                    nativeDriver = null;
+                    driverRestartScheduled = false;
+                    return;
+                }
+
+                restartReady = true;
+                restartContext = appContext;
+                driverRestartScheduled = false;
+            }
+
+            if (restartReady) {
+                notifyDriverEvent(replacement, restartContext, EVENT_SCREEN_ON, "restart_" + reason);
+            }
+        } catch (Throwable e) {
+            synchronized (lock) {
+                driverRestartScheduled = false;
+            }
+            writeMarker(context, "bridge.restartDriver.exception reason=" + reason + " "
+                    + e.getClass().getName() + ":" + e.getMessage());
+            Log.e(TAG, "Failed to restart DisplayLink driver, reason=" + reason, e);
+            return;
+        }
+
+        writeMarker(context, "bridge.restartDriver.probe reason=" + reason);
+        scheduleProbe("restart_" + reason, 150);
+        scheduleNotifyScreenOn("restart_" + reason, 300);
+    }
+
+    private void notifyDriverEvent(NativeDriver driver, @Nullable Context context, int eventCode, String reason) {
+        if (driver == null) {
+            return;
+        }
+
+        try {
+            driver.notifyEvent(eventCode);
+            writeMarker(context, "bridge.notifyEvent code=" + eventCode + " reason=" + reason);
+        } catch (Throwable e) {
+            writeMarker(context, "bridge.notifyEvent_failed code=" + eventCode + " reason=" + reason
+                    + " error=" + e.getClass().getSimpleName());
+            Log.w(TAG, "notifyEvent failed code=" + eventCode + " reason=" + reason, e);
+        }
+    }
+
+    private static boolean isDisplayLinkDevice(UsbDevice device) {
+        return device.getVendorId() == DISPLAYLINK_VENDOR_ID;
+    }
+
+    private void cleanupStaleConnections(HashMap<String, UsbDevice> devices) {
+        List<String> staleConnections = new ArrayList<>();
+        for (String deviceName : connections.keySet()) {
+            if (!devices.containsKey(deviceName)) {
+                staleConnections.add(deviceName);
+            }
+        }
+
+        for (String deviceName : staleConnections) {
+            writeMarker(appContext, "bridge.probeAttachedDevices.stale_detach name=" + deviceName);
+            detachDevice(deviceName);
+        }
+
+        synchronized (lock) {
+            pendingPermissionDevices.retainAll(devices.keySet());
+            deniedPermissionDevices.retainAll(devices.keySet());
+            attachingDevices.retainAll(devices.keySet());
+            if (outstandingPermissionDeviceName != null && !devices.containsKey(outstandingPermissionDeviceName)) {
+                outstandingPermissionDeviceName = null;
+                permissionRequestOutstanding = false;
+            }
+        }
+    }
+
+    private static File prepareFirmwareDirectory(Context context) throws IOException, PackageManager.NameNotFoundException {
+        Context displayLinkContext = context.createPackageContext(DISPLAYLINK_PACKAGE, 0);
+        AssetManager assets = displayLinkContext.getAssets();
+        File dir = context.getDir("displaylink-fw", Context.MODE_PRIVATE);
+        Log.i(TAG, "Preparing firmware directory at " + dir);
+        String[] assetNames = assets.list("");
+        if (assetNames == null) {
+            throw new IOException("DisplayLink asset list unavailable");
+        }
+
+        for (String assetName : assetNames) {
+            if (!assetName.endsWith(".spkg")) {
+                continue;
+            }
+
+            File outFile = new File(dir, assetName);
+            try (InputStream in = assets.open(assetName);
+                 FileOutputStream out = new FileOutputStream(outFile, false)) {
+                byte[] buffer = new byte[16384];
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, read);
+                }
+                out.getFD().sync();
+            }
+        }
+
+        return dir;
+    }
+}

--- a/app/src/main/java/com/termux/x11/displaylink/DisplayLinkDebugReceiver.java
+++ b/app/src/main/java/com/termux/x11/displaylink/DisplayLinkDebugReceiver.java
@@ -1,0 +1,55 @@
+package com.termux.x11.displaylink;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import com.termux.x11.MainActivity;
+
+public class DisplayLinkDebugReceiver extends BroadcastReceiver {
+    public static final String ACTION_START = "com.termux.x11.displaylink.START";
+    public static final String ACTION_STOP = "com.termux.x11.displaylink.STOP";
+    public static final String ACTION_RESTART = "com.termux.x11.displaylink.RESTART";
+    public static final String ACTION_RENDER = "com.termux.x11.displaylink.RENDER";
+    public static final String ACTION_MARK = "com.termux.x11.displaylink.MARK";
+    private static final String TAG = "DisplayLinkDebugReceiver";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent != null ? intent.getAction() : null;
+        DisplayLinkBridge.writeMarker(context, "receiver.onReceive action=" + action + " context=" + context);
+        Log.i(TAG, "Received action=" + action + " context=" + context);
+
+        if (ACTION_START.equals(action)) {
+            DisplayLinkBridge.writeMarker(context, "receiver.start_bridge");
+            DisplayLinkBridge.getInstance().start(context);
+        } else if (ACTION_STOP.equals(action)) {
+            DisplayLinkBridge.writeMarker(context, "receiver.stop_bridge");
+            DisplayLinkBridge.getInstance().stop();
+        } else if (ACTION_RESTART.equals(action)) {
+            String reason = intent.getStringExtra("reason");
+            if (reason == null || reason.isEmpty()) {
+                reason = "debug_receiver";
+            }
+            DisplayLinkBridge.writeMarker(context, "receiver.restart_bridge reason=" + reason);
+            DisplayLinkBridge.getInstance().restart(reason);
+        } else if (ACTION_RENDER.equals(action)) {
+            MainActivity activity = MainActivity.getInstance();
+            if (activity != null && activity.getLorieView() != null) {
+                DisplayLinkBridge.writeMarker(context, "receiver.request_render");
+                activity.runOnUiThread(() -> {
+                    DisplayLinkBridge.writeMarker(activity, "receiver.request_render.ui_begin");
+                    activity.getLorieView().requestRender();
+                    activity.getLorieView().triggerCallback();
+                    DisplayLinkBridge.writeMarker(activity, "receiver.request_render.ui_end");
+                });
+            } else {
+                DisplayLinkBridge.writeMarker(context, "receiver.request_render.skip no_activity");
+            }
+        } else if (ACTION_MARK.equals(action)) {
+            String note = intent.getStringExtra("note");
+            DisplayLinkBridge.writeMarker(context, "receiver.mark note=" + note);
+        }
+    }
+}


### PR DESCRIPTION
Introduces a complete hardware-accelerated rendering pipeline and USB bridge to output the Termux-X11 display directly to DisplayLink monitors and docks. 

- Driver Injection: Dynamically loads `libDisplayLinkManager.so` and extracts `.spkg` firmware from the official `com.displaylink.presenter` app, bypassing the need to bundle proprietary binaries.
- Native Render Sink: Intercepts the X11 drawing pipeline in `renderer.c`. Creates an offscreen FBO to render the root window and composite the hardware cursor, automatically scaling and letterboxing the output to match the connected monitor's preferred resolution.
- Zero-Copy JNI Pipeline: Utilizes `glReadPixels` to read raw RGBA buffers from the GL thread, passing them to the Java bridge via `DirectByteBuffer` for DisplayLink hardware encoding.
- USB Host Management: Adds `DisplayLinkBridge` to handle device hotplugging, DDC monitor info parsing, dynamic permission requests, and watchdog-based driver recovery.
- Diagnostics: Includes `DisplayLinkDebugReceiver` for adb-driven lifecycle control and marker-based PPM frame dumping for rendering isolation tests.

Note: Requires the official DisplayLink Presenter app to be installed on the host device.