### PR TITLE
feat(renderer): add initial zoom support.

### DIFF
--- a/app/src/main/cpp/lorie/activity.c
+++ b/app/src/main/cpp/lorie/activity.c
@@ -380,6 +380,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *vm, __unused void *reserved) {
             {"nativeInit", "()V", (void *)&nativeInit},
             {"surfaceChanged", "(Landroid/view/Surface;)V", (void *)&rendererSetWindow},
             {"setViewport", "(IIIIII)V", (void *)&rendererSetViewport},
+            {"setRendererZoom", "(I)V", (void *)&rendererSetZoom},
             {"setFiltering", "(I)V", (void *)&rendererSetFiltering},
             {"connect", "(I)V", (void *)&connect_},
             {"connected", "()Z", (void *)&connected},

--- a/app/src/main/cpp/lorie/lorie.h
+++ b/app/src/main/cpp/lorie/lorie.h
@@ -41,6 +41,7 @@ __unused void rendererSetFiltering(JNIEnv* env, jobject self, jint filtering);
 __unused void rendererTestCapabilities(int* legacy_drawing);
 __unused void rendererSetWindow(JNIEnv *env, jobject thiz, jobject sfc);
 __unused void rendererSetViewport(JNIEnv *env, jclass clazz, int x, int y, int w, int h, int ew, int eh);
+__unused void rendererSetZoom(JNIEnv *env, jclass clazz, int percent);
 __unused void rendererSetSharedState(struct lorie_shared_server_state* newState);
 __unused void rendererAddBuffer(LorieBuffer* buf);
 __unused void rendererRemoveBuffer(uint64_t id);

--- a/app/src/main/cpp/lorie/renderer.c
+++ b/app/src/main/cpp/lorie/renderer.c
@@ -20,6 +20,7 @@
 #include <android/log.h>
 #include <media/NdkImageReader.h>
 #include <dlfcn.h>
+#include <math.h>
 #include <sys/mman.h>
 #include "list.h"
 #include "lorie.h"
@@ -123,6 +124,13 @@ static volatile bool stateChanged = false, windowChanged = false;
 static volatile struct lorie_shared_server_state* pendingState = NULL;
 static volatile ANativeWindow* pendingWin = NULL;
 static volatile int viewportX = 0, viewportY = 0, viewportW = 0, viewportH = 0, expectedW = 0, expectedH = 0;
+static volatile int zoomPercent = 100;
+static float zoomSourceLeft = 0.f, zoomSourceTop = 0.f;
+static JNIEnv* rendererEnv = NULL;
+static jclass lorieViewClass = NULL;
+static jmethodID setRendererViewportMethod = NULL;
+static int reportedViewportX = -1, reportedViewportY = -1, reportedViewportW = -1, reportedViewportH = -1;
+static float reportedSourceLeft = -1.f, reportedSourceTop = -1.f, reportedSourceWidth = -1.f, reportedSourceHeight = -1.f;
 
 static pthread_mutex_t stateLock;
 static pthread_cond_t stateCond;
@@ -151,6 +159,33 @@ static inline __always_inline void bindTexture(GLuint id) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 }
 
+static void reportRendererViewport(int dstX, int dstY, int dstW, int dstH, float left, float top, float width, float height) {
+    JNIEnv* env = rendererEnv;
+    if (!env || !lorieViewClass || !setRendererViewportMethod)
+        return;
+
+    if (reportedViewportX == dstX && reportedViewportY == dstY &&
+        reportedViewportW == dstW && reportedViewportH == dstH &&
+        reportedSourceLeft == left && reportedSourceTop == top &&
+        reportedSourceWidth == width && reportedSourceHeight == height)
+        return;
+
+    (*env)->CallStaticVoidMethod(env, lorieViewClass, setRendererViewportMethod, dstX, dstY, dstW, dstH, left, top, width, height);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+    } else {
+        reportedViewportX = dstX;
+        reportedViewportY = dstY;
+        reportedViewportW = dstW;
+        reportedViewportH = dstH;
+        reportedSourceLeft = left;
+        reportedSourceTop = top;
+        reportedSourceWidth = width;
+        reportedSourceHeight = height;
+    }
+}
+
 static EGLint configAttribs[] = {
         EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
         EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
@@ -171,7 +206,13 @@ static void onImageAvailable(void* context, AImageReader* reader) {
         AImage_delete(image);
 }
 
-int rendererInitThread(void) {
+int rendererInitThread(void* cookie) {
+    JavaVM* vm = cookie;
+    if ((*vm)->AttachCurrentThread(vm, &rendererEnv, NULL) != JNI_OK) {
+        log("Failed to attach renderer thread to JVM");
+        return 0;
+    }
+
     EGLint major, minor;
     EGLint numConfigs;
     EGLint *const alphaAttrib = &configAttribs[11];
@@ -253,9 +294,15 @@ int rendererInitThread(void) {
 
 void rendererInit(JNIEnv* env) {
     pthread_t t;
+    JavaVM* vm;
 
     if (ctx)
         return;
+
+    (*env)->GetJavaVM(env, &vm);
+    jclass clazz = (*env)->FindClass(env, "com/termux/x11/LorieView");
+    lorieViewClass = (*env)->NewGlobalRef(env, clazz);
+    setRendererViewportMethod = (*env)->GetStaticMethodID(env, lorieViewClass, "setRendererViewport", "(IIIIFFFF)V");
 
     pthreadCondVarProxyInit();
 
@@ -264,7 +311,7 @@ void rendererInit(JNIEnv* env) {
     pthread_cond_init(&stateChangeFinishCond, NULL);
     pthread_spin_init(&bufferLock, false);
 
-    pthread_create(&t, NULL, (void*(*)(void*)) rendererInitThread, NULL);
+    pthread_create(&t, NULL, (void*(*)(void*)) rendererInitThread, vm);
 }
 void rendererSetFiltering(JNIEnv* env, jobject self, jint f) {
     filtering = f;
@@ -481,6 +528,21 @@ void rendererSetViewport(__unused JNIEnv *env, __unused jclass clazz, int x, int
     viewportH = h;
     expectedW = ew;
     expectedH = eh;
+    reportedViewportX = reportedViewportY = reportedViewportW = reportedViewportH = -1;
+    reportedSourceLeft = reportedSourceTop = reportedSourceWidth = reportedSourceHeight = -1.f;
+    if (state)
+        state->drawRequested = true;
+    pthread_cond_signal(&stateCond);
+    pthread_mutex_unlock(&stateLock);
+}
+
+void rendererSetZoom(__unused JNIEnv *env, __unused jclass clazz, int percent) {
+    pthread_mutex_lock(&stateLock);
+    zoomPercent = percent < 100 ? 100 : (percent > 400 ? 400 : percent);
+    reportedViewportX = reportedViewportY = reportedViewportW = reportedViewportH = -1;
+    reportedSourceLeft = reportedSourceTop = reportedSourceWidth = reportedSourceHeight = -1.f;
+    if (zoomPercent == 100)
+        zoomSourceLeft = zoomSourceTop = 0.f;
     if (state)
         state->drawRequested = true;
     pthread_cond_signal(&stateCond);
@@ -531,8 +593,8 @@ void rendererRefreshContext(void) {
     log("Xlorie: new surface applied: %p\n", sfc);
 }
 
-static void draw(GLuint id, float x0, float y0, float x1, float y1, float xfactor, uint8_t flip);
-static void drawCursor(float displayWidth, float displayHeight);
+static void drawRegion(GLuint id, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, uint8_t flip);
+static void drawCursor(float displayWidth, float displayHeight, float sourceLeft, float sourceTop);
 
 void rendererRedrawLocked(bool* waitingForBuffers) {
     float xfactor = 1.f;
@@ -565,7 +627,76 @@ void rendererRedrawLocked(bool* waitingForBuffers) {
     }
 
     int surfaceH = ANativeWindow_getHeight(win);
-    glViewport(viewportX, surfaceH - viewportY - viewportH, viewportW, viewportH);
+    int surfaceW = ANativeWindow_getWidth(win);
+    int renderViewportX = viewportX, renderViewportY = viewportY, renderViewportW = viewportW, renderViewportH = viewportH;
+    float destinationScaleX = 1.f, destinationScaleY = 1.f;
+    if (zoomPercent > 100 && viewportW > 0 && viewportH > 0) {
+        float requestedScale = (float) zoomPercent / 100.f;
+        float centerX = (float) viewportX + (float) viewportW / 2.f;
+        float centerY = (float) viewportY + (float) viewportH / 2.f;
+        float maxW = 2.f * fminf(centerX, (float) surfaceW - centerX);
+        float maxH = 2.f * fminf(centerY, (float) surfaceH - centerY);
+        destinationScaleX = fminf(requestedScale, maxW / (float) viewportW);
+        destinationScaleY = fminf(requestedScale, maxH / (float) viewportH);
+        if (destinationScaleX < 1.f)
+            destinationScaleX = 1.f;
+        if (destinationScaleY < 1.f)
+            destinationScaleY = 1.f;
+
+        renderViewportW = (int) ((float) viewportW * destinationScaleX + 0.5f);
+        renderViewportH = (int) ((float) viewportH * destinationScaleY + 0.5f);
+        renderViewportX = (int) (centerX - (float) renderViewportW / 2.f + 0.5f);
+        renderViewportY = (int) (centerY - (float) renderViewportH / 2.f + 0.5f);
+    }
+
+    glDisable(GL_SCISSOR_TEST);
+    glViewport(0, 0, surfaceW, surfaceH);
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glViewport(renderViewportX, surfaceH - renderViewportY - renderViewportH, renderViewportW, renderViewportH);
+    float sourceLeft = 0.f, sourceTop = 0.f;
+    float sourceWidth = (float) desc->width, sourceHeight = (float) desc->height;
+    float logicalSourceWidth = (float) expectedW, logicalSourceHeight = (float) expectedH;
+    if (zoomPercent > 100) {
+        float requestedScale = (float) zoomPercent / 100.f;
+        sourceWidth = (float) expectedW * destinationScaleX / requestedScale;
+        sourceHeight = (float) expectedH * destinationScaleY / requestedScale;
+        logicalSourceWidth = sourceWidth;
+        logicalSourceHeight = sourceHeight;
+        // Keep the zoomed region stable while the cursor stays inside the central 90%.
+        // Only pan when the cursor enters this 5% edge band near any side.
+        float edgeX = sourceWidth * 0.05f;
+        float edgeY = sourceHeight * 0.05f;
+        float cursorX = (float) state->cursor.x;
+        float cursorY = (float) state->cursor.y;
+
+        if (cursorX < zoomSourceLeft + edgeX)
+            zoomSourceLeft = cursorX - edgeX;
+        else if (cursorX > zoomSourceLeft + sourceWidth - edgeX)
+            zoomSourceLeft = cursorX - sourceWidth + edgeX;
+
+        if (cursorY < zoomSourceTop + edgeY)
+            zoomSourceTop = cursorY - edgeY;
+        else if (cursorY > zoomSourceTop + sourceHeight - edgeY)
+            zoomSourceTop = cursorY - sourceHeight + edgeY;
+
+        if (zoomSourceLeft < 0.f)
+            zoomSourceLeft = 0.f;
+        else if (zoomSourceLeft + sourceWidth > (float) expectedW)
+            zoomSourceLeft = (float) expectedW - sourceWidth;
+
+        if (zoomSourceTop < 0.f)
+            zoomSourceTop = 0.f;
+        else if (zoomSourceTop + sourceHeight > (float) expectedH)
+            zoomSourceTop = (float) expectedH - sourceHeight;
+
+        sourceLeft = zoomSourceLeft;
+        sourceTop = zoomSourceTop;
+    } else
+        zoomSourceLeft = zoomSourceTop = 0.f;
+
+    reportRendererViewport(renderViewportX, renderViewportY, renderViewportW, renderViewportH,
+                           sourceLeft, sourceTop, logicalSourceWidth, logicalSourceHeight);
 
     // We should signal X server to not use root window while we actively copy it
     lorie_mutex_lock(&state->lock, &state->lockingPid);
@@ -574,7 +705,11 @@ void rendererRedrawLocked(bool* waitingForBuffers) {
     LorieBuffer_bindTexture(buffer);
     if (desc->type == LORIEBUFFER_FD)
         xfactor = (float) desc->width/(float) desc->stride;
-    draw(0, -1.f, -1.f, 1.f, 1.f, xfactor, LorieBuffer_isRgba(buffer));
+    drawRegion(0, -1.f, -1.f, 1.f, 1.f,
+               sourceLeft / (float) desc->width * xfactor, sourceTop / (float) desc->height,
+               (sourceLeft + sourceWidth) / (float) desc->width * xfactor,
+               (sourceTop + sourceHeight) / (float) desc->height,
+               LorieBuffer_isRgba(buffer));
     fence = eglCreateSyncKHR(egl_display, EGL_SYNC_FENCE_KHR, NULL);
     glFlush();
 
@@ -588,7 +723,7 @@ void rendererRedrawLocked(bool* waitingForBuffers) {
     }
 
     state->cursor.moved = FALSE;
-    drawCursor((float) (LorieBuffer_getWidth(buffer)), (float) (LorieBuffer_getHeight(buffer)));
+    drawCursor(sourceWidth, sourceHeight, sourceLeft, sourceTop);
     glFlush();
 
     // Wait until root window drawing is finished before giving control back to X server
@@ -753,12 +888,12 @@ static GLuint createProgram(const char* p_vertex_source, const char* p_fragment_
     return 0;
 }
 
-static void draw(GLuint id, float x0, float y0, float x1, float y1, float xfactor, uint8_t flip) {
+static void drawRegion(GLuint id, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, uint8_t flip) {
     float coords[16] = {
-        x0, -y0, 0.f, 0.f,
-        x1, -y0, xfactor, 0.f,
-        x0, -y1, 0.f, 1.f,
-        x1, -y1, xfactor, 1.f,
+        x0, -y0, u0, v0,
+        x1, -y0, u1, v0,
+        x0, -y1, u0, v1,
+        x1, -y1, u1, v1,
     };
 
     GLuint p = flip ? gv_pos_bgra : gv_pos, c = flip ? gv_coords_bgra : gv_coords;
@@ -777,19 +912,19 @@ static void draw(GLuint id, float x0, float y0, float x1, float y1, float xfacto
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4); checkGlError();
 }
 
-__unused static void drawCursor(float displayWidth, float displayHeight) {
+__unused static void drawCursor(float displayWidth, float displayHeight, float sourceLeft, float sourceTop) {
     float x, y, w, h;
 
     if (!state->cursor.width || !state->cursor.height)
         return;
 
-    x = 2.f * ((float) state->cursor.x - (float) state->cursor.xhot) / displayWidth - 1.f;
-    y = 2.f * ((float) state->cursor.y - (float) state->cursor.yhot) / displayHeight - 1.f;
+    x = 2.f * ((float) state->cursor.x - sourceLeft - (float) state->cursor.xhot) / displayWidth - 1.f;
+    y = 2.f * ((float) state->cursor.y - sourceTop - (float) state->cursor.yhot) / displayHeight - 1.f;
     w = 2.f * (float) state->cursor.width / displayWidth;
     h = 2.f * (float) state->cursor.height / displayHeight;
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    draw(cursor.id, x, y, x + w, y + h, 1.f, false);
+    drawRegion(cursor.id, x, y, x + w, y + h, 0.f, 0.f, 1.f, 1.f, false);
     glDisable(GL_BLEND);
 }
 

--- a/app/src/main/java/com/termux/x11/LorieView.java
+++ b/app/src/main/java/com/termux/x11/LorieView.java
@@ -26,6 +26,7 @@ import android.text.Selection;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.Display;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
@@ -52,6 +53,7 @@ import androidx.core.math.MathUtils;
 
 import com.termux.x11.input.InputStub;
 import com.termux.x11.input.TouchInputHandler;
+import com.termux.x11.utils.SamsungDexUtils;
 
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -332,8 +334,10 @@ class InputConnectionWrapper implements InputConnection {
 @Keep @SuppressLint("WrongConstant")
 @SuppressWarnings("deprecation")
 public class LorieView extends SurfaceView implements InputStub {
+    private static int rendererZoom = 100;
+
     public interface Callback {
-        void changed(int surfaceWidth, int surfaceHeight, int screenWidth, int screenHeight, Matrix inputTransform);
+        void inputTransformChanged(int screenWidth, int screenHeight, Matrix inputTransform);
     }
 
     interface PixelFormat {
@@ -349,7 +353,10 @@ public class LorieView extends SurfaceView implements InputStub {
     private final Point p = new Point();
     private final Rect contentInsets = new Rect();
     private final Rect viewport = new Rect();
+    private final Rect inputViewport = new Rect();
     private final Matrix inputTransform = new Matrix();
+    private float inputSourceLeft = 0.f, inputSourceTop = 0.f;
+    private float inputSourceWidth = 0.f, inputSourceHeight = 0.f;
     boolean commitedText = false;
     private final InputConnection mConnection = new InputConnectionWrapper(new BaseInputConnection(this, false) {
         private final MainActivity a = MainActivity.getInstance();
@@ -648,9 +655,48 @@ public class LorieView extends SurfaceView implements InputStub {
 
     private Matrix getInputTransform() {
         inputTransform.reset();
-        inputTransform.postTranslate(-viewport.left, -viewport.top);
-        inputTransform.postScale((float) p.x / (float) viewport.width(), (float) p.y / (float) viewport.height());
+        inputTransform.postTranslate(-inputViewport.left, -inputViewport.top);
+        inputTransform.postScale(inputSourceWidth / (float) inputViewport.width(), inputSourceHeight / (float) inputViewport.height());
+        inputTransform.postTranslate(inputSourceLeft, inputSourceTop);
         return new Matrix(inputTransform);
+    }
+
+    private void updateInputTransform() {
+        if (mCallback != null)
+            mCallback.inputTransformChanged(p.x, p.y, getInputTransform());
+    }
+
+    private void sendWindowChange() {
+        String name;
+        int framerate = (int) (getDisplay() != null ? getDisplay().getRefreshRate() : 30);
+
+        if (getDisplay() == null || getDisplay().getDisplayId() == Display.DEFAULT_DISPLAY)
+            name = "builtin";
+        else if (SamsungDexUtils.checkDeXEnabled(MainActivity.getInstance()))
+            name = "dex";
+        else
+            name = "external";
+
+        sendWindowChange(p.x, p.y, framerate, name);
+    }
+
+    @Keep
+    @SuppressWarnings("unused")
+    private static void setRendererViewport(int viewportLeft, int viewportTop, int viewportWidth, int viewportHeight,
+                                            float sourceLeft, float sourceTop, float sourceWidth, float sourceHeight) {
+        MainActivity.handler.post(() -> {
+            MainActivity activity = MainActivity.getInstance();
+            if (activity == null)
+                return;
+
+            LorieView view = activity.getLorieView();
+            view.inputViewport.set(viewportLeft, viewportTop, viewportLeft + viewportWidth, viewportTop + viewportHeight);
+            view.inputSourceLeft = sourceLeft;
+            view.inputSourceTop = sourceTop;
+            view.inputSourceWidth = sourceWidth;
+            view.inputSourceHeight = sourceHeight;
+            view.updateInputTransform();
+        });
     }
 
     public void setContentInsets(int left, int top, int right, int bottom) {
@@ -688,10 +734,16 @@ public class LorieView extends SurfaceView implements InputStub {
         int top = availableTop + (availableH - drawH) / 2;
 
         viewport.set(left, top, left + drawW, top + drawH);
+        if (rendererZoom == 100 || inputSourceWidth == 0.f || inputSourceHeight == 0.f) {
+            inputViewport.set(viewport);
+            inputSourceLeft = inputSourceTop = 0.f;
+            inputSourceWidth = p.x;
+            inputSourceHeight = p.y;
+        }
         setViewport(viewport.left, viewport.top, viewport.width(), viewport.height(), p.x, p.y);
 
-        if (mCallback != null)
-            mCallback.changed(availableW, availableH, p.x, p.y, getInputTransform());
+        updateInputTransform();
+        sendWindowChange();
     }
 
     @Override
@@ -859,6 +911,18 @@ public class LorieView extends SurfaceView implements InputStub {
     @FastNative public native void sendClipboardEvent(byte[] text);
     @FastNative static native void sendWindowChange(int width, int height, int framerate, String name);
     @FastNative static native void setViewport(int x, int y, int width, int height, int expectedWidth, int expectedHeight);
+    @FastNative private static native void setRendererZoom(int percent);
+
+    public void adjustRendererZoom(int delta) {
+        rendererZoom = MathUtils.clamp(rendererZoom + delta, 100, 400);
+        setRendererZoom(rendererZoom);
+    }
+
+    public void resetRendererZoom() {
+        rendererZoom = 100;
+        setRendererZoom(rendererZoom);
+    }
+
     @FastNative public native void sendMouseEvent(float x, float y, int whichButton, boolean buttonDown, boolean relative);
     @FastNative public native void sendTouchEvent(int action, int id, int x, int y);
     @FastNative public native void sendStylusEvent(float x, float y, int pressure, int tiltX, int tiltY, int orientation, int buttons, boolean eraser, boolean mouseMode);

--- a/app/src/main/java/com/termux/x11/MainActivity.java
+++ b/app/src/main/java/com/termux/x11/MainActivity.java
@@ -36,7 +36,6 @@ import android.os.SystemClock;
 import android.service.notification.StatusBarNotification;
 import android.util.DisplayMetrics;
 import android.util.Log;
-import android.view.Display;
 import android.view.DragEvent;
 import android.view.InputDevice;
 import android.view.KeyEvent;
@@ -65,7 +64,6 @@ import com.termux.x11.input.InputStub;
 import com.termux.x11.input.TouchInputHandler;
 import com.termux.x11.utils.FullscreenWorkaround;
 import com.termux.x11.utils.KeyInterceptor;
-import com.termux.x11.utils.SamsungDexUtils;
 import com.termux.x11.utils.TermuxX11ExtraKeys;
 import com.termux.x11.utils.X11ToolbarViewPager;
 
@@ -126,11 +124,19 @@ public class MainActivity extends AppCompatActivity {
     ViewTreeObserver.OnPreDrawListener mOnPredrawListener = new ViewTreeObserver.OnPreDrawListener() {
         @Override
         public boolean onPreDraw() {
-            if (LorieView.connected())
-                handler.post(() -> findViewById(android.R.id.content).getViewTreeObserver().removeOnPreDrawListener(mOnPredrawListener));
-            return false;
+            if (!LorieView.connected())
+                return false;
+
+            finishStartupDraw();
+            return true;
         }
     };
+
+    private void finishStartupDraw() {
+        View content = findViewById(android.R.id.content);
+        content.getViewTreeObserver().removeOnPreDrawListener(mOnPredrawListener);
+        content.invalidate();
+    }
 
     @SuppressLint("StaticFieldLeak")
     private static MainActivity instance;
@@ -199,21 +205,8 @@ public class MainActivity extends AppCompatActivity {
         lorieParent.setOnCapturedPointerListener((v, e) -> mInputHandler.handleTouchEvent(lorieView, lorieView, e));
         lorieView.setOnKeyListener(mLorieKeyListener);
 
-        lorieView.setCallback((surfaceWidth, surfaceHeight, screenWidth, screenHeight, inputTransform) -> {
-            String name;
-            int framerate = (int) ((lorieView.getDisplay() != null) ? lorieView.getDisplay().getRefreshRate() : 30);
-
-            mInputHandler.handleHostSizeChanged(surfaceWidth, surfaceHeight);
-            mInputHandler.handleClientSizeChanged(screenWidth, screenHeight);
-            mInputHandler.handleInputTransformChanged(inputTransform);
-            if (lorieView.getDisplay() == null || lorieView.getDisplay().getDisplayId() == Display.DEFAULT_DISPLAY)
-                name = "builtin";
-            else if (SamsungDexUtils.checkDeXEnabled(this))
-                name = "dex";
-            else
-                name = "external";
-            LorieView.sendWindowChange(screenWidth, screenHeight, framerate, name);
-        });
+        lorieView.setCallback((screenWidth, screenHeight, inputTransform) ->
+                mInputHandler.handleInputTransformChanged(screenWidth, screenHeight, inputTransform));
 
         registerReceiver(receiver, new IntentFilter(ACTION_START) {{
             addAction(ACTION_PREFERENCES_CHANGED);
@@ -232,7 +225,7 @@ public class MainActivity extends AppCompatActivity {
         if (tryConnect()) {
             final View content = findViewById(android.R.id.content);
             content.getViewTreeObserver().addOnPreDrawListener(mOnPredrawListener);
-            handler.postDelayed(() -> content.getViewTreeObserver().removeOnPreDrawListener(mOnPredrawListener), 500);
+            handler.postDelayed(this::finishStartupDraw, 500);
         }
         onPreferencesChanged("");
 
@@ -553,6 +546,7 @@ public class MainActivity extends AppCompatActivity {
             if (fd != null) {
                 Log.v("MainActivity", "Extracting X connection socket.");
                 LorieView.connect(fd.detachFd());
+                finishStartupDraw();
                 getLorieView().triggerCallback();
                 clientConnectedStateChanged();
                 getLorieView().reloadPreferences(prefs);

--- a/app/src/main/java/com/termux/x11/input/RenderData.java
+++ b/app/src/main/java/com/termux/x11/input/RenderData.java
@@ -16,9 +16,6 @@ public class RenderData {
 
     public int screenWidth;
     public int screenHeight;
-    public int imageWidth;
-    public int imageHeight;
-
     /**
      * Specifies the position, in image coordinates, at which the cursor image will be drawn.
      * This will normally be at the location of the most recently injected motion event.

--- a/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -94,6 +94,7 @@ public class TouchInputHandler {
     private final MainActivity mActivity;
     private final DisplayMetrics mMetrics = new DisplayMetrics();
     private final float[] mappedPoint = new float[2];
+    private final float[] matrixValues = new float[9];
 
     private final BiConsumer<Integer, Boolean> noAction = (key, down) -> {};
     private BiConsumer<Integer, Boolean> swipeUpAction = noAction, swipeDownAction = noAction,
@@ -362,39 +363,16 @@ public class TouchInputHandler {
         return false;
     }
 
-    private void resetTransformation() {
-        float sx = (float) mRenderData.screenWidth / (float) mRenderData.imageWidth;
-        float sy = (float) mRenderData.screenHeight / (float) mRenderData.imageHeight;
-        mRenderData.scale.set(sx, sy);
-
-        Matrix fallbackTransform = new Matrix();
-        fallbackTransform.postScale(sx, sy);
-        mRenderData.setInputTransform(fallbackTransform);
-    }
-
-    public void handleInputTransformChanged(Matrix inputTransform) {
+    public void handleInputTransformChanged(int screenWidth, int screenHeight, Matrix inputTransform) {
+        inputTransform.getValues(matrixValues);
+        mRenderData.scale.set(matrixValues[Matrix.MSCALE_X], matrixValues[Matrix.MSCALE_Y]);
+        mRenderData.screenWidth = screenWidth;
+        mRenderData.screenHeight = screenHeight;
         mRenderData.setInputTransform(inputTransform);
-    }
-
-    public void handleClientSizeChanged(int w, int h) {
-        mRenderData.screenWidth = w;
-        mRenderData.screenHeight = h;
-
-        if (mTouchpadHandler != null)
-            mTouchpadHandler.handleClientSizeChanged(w, h);
-
-        resetTransformation();
-    }
-
-    public void handleHostSizeChanged(int w, int h) {
-        mRenderData.imageWidth = w;
-        mRenderData.imageHeight = h;
-
-        if (mTouchpadHandler != null)
-            mTouchpadHandler.handleHostSizeChanged(w, h);
-
-        resetTransformation();
         MainActivity.getRealMetrics(mMetrics);
+
+        if (mTouchpadHandler != null)
+            mTouchpadHandler.handleInputTransformChanged(screenWidth, screenHeight, inputTransform);
     }
 
     public void setInputMode(@InputMode int inputMode) {
@@ -967,13 +945,12 @@ public class TouchInputHandler {
 
             if (MainActivity.getInstance().getLorieView().hasPointerCapture() &&
                     isExternal(dev) && rangeX != null && rangeY != null) {
-                newX *= mRenderData.imageWidth / rangeX.getMax();
-                newY *= mRenderData.imageHeight / rangeY.getMax();
-            } else {
-                mRenderData.mapScreenPoint(newX, newY, mappedPoint);
-                newX = mappedPoint[0];
-                newY = mappedPoint[1];
+                newX *= (float) mMetrics.widthPixels / rangeX.getMax();
+                newY *= (float) mMetrics.heightPixels / rangeY.getMax();
             }
+            mRenderData.mapScreenPoint(newX, newY, mappedPoint);
+            newX = mappedPoint[0];
+            newY = mappedPoint[1];
 
             if (x == newX && y == newY && pressure == e.getPressure() && tilt == e.getAxisValue(MotionEvent.AXIS_TILT) &&
                     orientation == e.getAxisValue(MotionEvent.AXIS_ORIENTATION) && buttons == newButtons)

--- a/app/src/main/java/com/termux/x11/utils/TermuxX11ExtraKeys.java
+++ b/app/src/main/java/com/termux/x11/utils/TermuxX11ExtraKeys.java
@@ -185,6 +185,12 @@ public class TermuxX11ExtraKeys implements ExtraKeysView.IExtraKeysView {
             mActivity.toggleMouseAuxButtons();
         else if ("STYLUS_HELPER".equals(key))
             mActivity.toggleStylusAuxButtons();
+        else if ("ZOOM_IN".equals(key))
+            mActivity.getLorieView().adjustRendererZoom(25);
+        else if ("ZOOM_OUT".equals(key))
+            mActivity.getLorieView().adjustRendererZoom(-25);
+        else if ("ZOOM_RESET".equals(key))
+            mActivity.getLorieView().resetRendererZoom();
         else
             onTerminalExtraKeyButtonClick(view, key, ctrlDown, altDown, shiftDown, metaDown, fnDown);
     }


### PR DESCRIPTION
Adds initial support for renderer-side zoom.

Zoom can be controlled from the extra keys bar with `ZOOM_IN`, `ZOOM_OUT`, and `ZOOM_RESET`. The zoomed view follows the X11 cursor while avoiding constant movement during normal pointer motion.

This is a first step toward zoom support, with the controls and renderer behavior in place but no dedicated settings UI yet.

Fixes #597, fixes #636, fixes #669.
