### PR TITLE
fix(input): delay IME reset to prevent stuck modifier keys from soft keyboard

### DIFF
--- a/app/src/main/java/com/termux/x11/LorieView.java
+++ b/app/src/main/java/com/termux/x11/LorieView.java
@@ -842,10 +842,12 @@ public class LorieView extends SurfaceView implements InputStub {
         if (!commitedText)
             return;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
-            mIMM.invalidateInput(this);
-        else
-            mIMM.restartInput(this);
+        postDelayed(() -> {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                mIMM.invalidateInput(this);
+            else
+                mIMM.restartInput(this);
+        }, 10);
     }
 
     @FastNative private native void nativeInit();


### PR DESCRIPTION
resetIme() was calling invalidateInput/restartInput synchronously. If the soft keyboard (e.g. Unexpected Keyboard) had not yet sent key-up for a latched modifier before the IMF closed its connection, the modifier would get stuck in X11. Delaying by 10ms gives the IME time to finish sending modifier release events before the connection is reset.

Fixes #904