### PR TITLE
fix(input): treat external touchpad finger taps as touchpad events

### DIFF
--- a/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -265,7 +265,14 @@ public class TouchInputHandler {
     }
 
     boolean isDexEvent(MotionEvent event) {
-        int SOURCE_DEX = InputDevice.SOURCE_MOUSE | InputDevice.SOURCE_TOUCHSCREEN;
+        // Besides Samsung DeX, several external pointing devices (e.g. some
+        // Bluetooth keyboard+touchpad combos, see #1011) report their taps as
+        // SOURCE_MOUSE + TOOL_TYPE_FINGER (but not SOURCE_TOUCHPAD). Match those
+        // too so they go through the touchpad gesture path and tap-to-click /
+        // multi-finger taps work, instead of the hardware-mouse path which only
+        // forwards physical button state. Real mice use TOOL_TYPE_MOUSE and real
+        // touchpads report SOURCE_TOUCHPAD, so neither is affected.
+        int SOURCE_DEX = InputDevice.SOURCE_MOUSE;
         return ((event.getSource() & SOURCE_DEX) == SOURCE_DEX)
                 && ((event.getSource() & InputDevice.SOURCE_TOUCHPAD) != InputDevice.SOURCE_TOUCHPAD)
                 && (event.getToolType(event.getActionIndex()) == MotionEvent.TOOL_TYPE_FINGER);


### PR DESCRIPTION
## Problem

On some external pointing devices — notably certain Bluetooth keyboard+touchpad combos (e.g. a "Cube Pocket Keyboard", and the Lenovo touchpads reported in #1011) — the touchpad **moves the cursor and physical button clicks work, but tap‑to‑click and multi‑finger taps are silently dropped** inside the X11 window. The same taps work fine in regular Android apps. A separate Bluetooth mouse works fully.

## Root cause

These devices report their taps as `SOURCE_MOUSE` + `TOOL_TYPE_FINGER` (and **not** `SOURCE_TOUCHPAD`).

`TouchInputHandler.isDexEvent()` only matched the Samsung DeX signature `SOURCE_MOUSE | SOURCE_TOUCHSCREEN`, so these events did not qualify as a "dex"/touchpad event. In `handleTouchEvent()` they therefore fell into the **hardware‑mouse path** (`HardwareMouseListener`), which only forwards physical button‑state changes. A physical click becomes `BUTTON_PRIMARY` (works), but a finger *tap* produces no button‑state delta, so nothing reaches the X server.

## Fix

Match any `SOURCE_MOUSE` + `TOOL_TYPE_FINGER` event (still excluding `SOURCE_TOUCHPAD`) in `isDexEvent()`, so these devices are routed through the existing touchpad/DeX gesture path. That path already turns finger gestures into pointer events, enabling **tap → left click, two‑finger tap → right click, three‑finger tap → middle click**, plus movement.

```diff
-        int SOURCE_DEX = InputDevice.SOURCE_MOUSE | InputDevice.SOURCE_TOUCHSCREEN;
+        int SOURCE_DEX = InputDevice.SOURCE_MOUSE;
```

This does not affect:
- **Regular mice** — they use `TOOL_TYPE_MOUSE`, not `TOOL_TYPE_FINGER`, so they keep using the hardware‑mouse path.
- **Real touchpads** — they report `SOURCE_TOUCHPAD`, which is still excluded.

## Testing

Built from source and installed on a Lenovo Legion Y700 (2nd gen, ZUI / Android 15) with a Bluetooth keyboard+touchpad combo. After the change, inside the X11 (XFCE) session the touchpad does movement, tap‑to‑click and two‑finger right‑click correctly; a separate Bluetooth mouse continues to work unchanged.

Closes #1011.