### PR TITLE
fix(input): filter spurious key events from touchscreen hardware

### DIFF
--- a/app/src/main/java/com/termux/x11/input/InputEventSender.java
+++ b/app/src/main/java/com/termux/x11/input/InputEventSender.java
@@ -40,6 +40,7 @@ public final class InputEventSender {
     public boolean pauseKeyInterceptingWithEsc = false;
     public boolean stylusIsMouse = false;
     public boolean stylusButtonContactModifierMode = false;
+    public boolean filterTouchscreenKeyEvents = true;
 
     /** Set of pressed keys for which we've sent TextEvent. */
     private final TreeSet<Integer> mPressedTextKeys;
@@ -178,6 +179,12 @@ public final class InputEventSender {
     public boolean sendKeyEvent(KeyEvent e) {
         int keyCode = e.getKeyCode();
         boolean pressed = e.getAction() == KeyEvent.ACTION_DOWN;
+
+        // Filter spurious key events from touchscreen hardware (e.g. Oplus/OnePlus
+        // touchpanel firmware injecting F-keys during touch/mouse operations).
+        if (filterTouchscreenKeyEvents && TouchInputHandler.sTouchpanelDeviceIds.contains(e.getDeviceId())) {
+            return true;
+        }
 
         if ((e.getFlags() & KeyEvent.FLAG_CANCELED) == KeyEvent.FLAG_CANCELED) {
             android.util.Log.d("KeyEvent", "We've got key event with FLAG_CANCELED, it will not be consumed. Details: " + e);

--- a/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/app/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -42,7 +42,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 
@@ -137,6 +139,7 @@ public class TouchInputHandler {
     private boolean mIsDragging;
     private static DisplayManager mDisplayManager;
     private static int mDisplayRotation;
+    static final Set<Integer> sTouchpanelDeviceIds = new HashSet<>();
     private static final DisplayManager.DisplayListener mDisplayListener = new DisplayManager.DisplayListener() {
         @Override
         public void onDisplayAdded(int displayId) {
@@ -242,13 +245,15 @@ public class TouchInputHandler {
     static public void refreshInputDevices() {
         AtomicBoolean stylusAvailable = new AtomicBoolean(false);
         AtomicBoolean externalKeyboardAvailable = new AtomicBoolean(false);
+        sTouchpanelDeviceIds.clear();
         android.util.Log.d("DEVICES", "external keyboard connected " + stylusAvailable.get());
         Arrays.stream(InputDevice.getDeviceIds())
                 .mapToObj(InputDevice::getDevice)
                 .filter(Objects::nonNull)
                 .forEach((device) -> {
                     //noinspection DataFlowIssue
-                    android.util.Log.d("DEVICES", "found device \"" + device.getName() + "\" " +
+                    String name = device.getName();
+                    android.util.Log.d("DEVICES", "found device \"" + name + "\" " +
                             (device.supportsSource(InputDevice.SOURCE_STYLUS) ? ((isExternal(device) ? "external " : "") + "stylus ") : "") +
                             ((device.supportsSource(InputDevice.SOURCE_KEYBOARD) && device.getKeyboardType() == InputDevice.KEYBOARD_TYPE_ALPHABETIC) ? ((isExternal(device) ? "external " : "") + "keyboard ") : "") +
                             "sources " + String.format("0x%08X", device.getSources()));
@@ -258,6 +263,9 @@ public class TouchInputHandler {
 
                     if (device.supportsSource(InputDevice.SOURCE_KEYBOARD) && device.getKeyboardType() == InputDevice.KEYBOARD_TYPE_ALPHABETIC && isExternal(device))
                         externalKeyboardAvailable.set(true);
+
+                    if (name != null && name.toLowerCase().contains("touchpanel"))
+                        sTouchpanelDeviceIds.add(device.getId());
                 });
         android.util.Log.d("DEVICES", "requesting stylus " + stylusAvailable.get());
         android.util.Log.d("DEVICES", "external keyboard connected " + externalKeyboardAvailable.get());
@@ -436,6 +444,7 @@ public class TouchInputHandler {
         mInjector.stylusIsMouse = p.stylusIsMouse.get();
         mInjector.stylusButtonContactModifierMode = p.stylusButtonContactModifierMode.get();
         mInjector.pauseKeyInterceptingWithEsc = p.pauseKeyInterceptingWithEsc.get();
+        mInjector.filterTouchscreenKeyEvents = p.filterTouchscreenKeyEvents.get();
         switch (p.transformCapturedPointer.get()) {
             case "c":
                 capturedPointerTransformation = CapturedPointerTransformation.CLOCKWISE;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,8 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="lorie_pref_filterOutWinkey_summary">Allows you to use Dex shortcuts while intercepting. Requires Accessibility service to work.</string>
     <string name="lorie_pref_enforceCharBasedInput">Enforce char based input</string>
     <string name="lorie_pref_enforceCharBasedInput_summary">Suppresses suggestions, predictive typing and CJK languages</string>
+    <string name="lorie_pref_filterTouchscreenKeyEvents">Filter touchscreen key events</string>
+    <string name="lorie_pref_filterTouchscreenKeyEvents_summary">Ignore keyboard events from touchscreen hardware (fixes spurious F-keys on some devices)</string>
 
     <string name="lorie_pref_clipboardEnable">Clipboard sharing</string>
     <string name="lorie_pref_requestNotificationPermission">Request notification permission</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -52,6 +52,7 @@
         <SwitchPreferenceCompat app:key="pauseKeyInterceptingWithEsc" app:defaultValue="false" />
         <SwitchPreferenceCompat app:key="filterOutWinkey" app:defaultValue="false" />
         <SwitchPreferenceCompat app:key="enforceCharBasedInput" app:defaultValue="false" />
+        <SwitchPreferenceCompat app:key="filterTouchscreenKeyEvents" app:defaultValue="true" />
     </PreferenceScreen>
     <PreferenceScreen app:key="other">
         <SwitchPreferenceCompat app:key="clipboardEnable" app:defaultValue="true" />


### PR DESCRIPTION
## Problem

On some devices with Oplus/OnePlus touchpanel firmware, the kernel module `oplus_keyevent_notifier` registers the touchscreen as a keyboard input source. During touch and mouse operations the touchpanel injects spurious function key events (e.g. F4 on Android keycode 134) into the input pipeline.

These events reach the X server as real key presses, causing unexpected modifier/function key behavior in X11 applications. For example, `^J` (Justify) being triggered in nano when moving the mouse.

## Root cause

The touchpanel hardware (`device=touchpanel1`) reports events with `source=0x101` (SOURCE_KEYBOARD) and valid scancodes. Termux:X11 forwards all keyboard events unconditionally. There is no mechanism to distinguish legitimate keyboard input from touchscreen-generated key events.

## Fix

Add a boolean preference `filterTouchscreenKeyEvents` (enabled by default) in the Keyboard settings screen. When enabled, `InputEventSender.sendKeyEvent()` checks if the event's device name contains "touchpanel" and silently discards the event before any further processing.

This is safe because:
- Real keyboards have device names like "Virtual", "bluetooth keyboard", etc.
- IME text input goes through `commitText()`, not `sendKeyEvent()`
- The filter only affects the `EVENT_KEY` path, not text or IME input
- Users with unaffected devices can disable the filter in settings

## Testing

Built and tested on an Oplus device (Android 15 / ARM64) with chroot XFCE via Termux:X11. After the fix, spurious F4 key events from touchpanel1 are filtered and no longer reach the X server. Normal keyboard input and IME text input continue to work correctly.