### PR TITLE
feat(input): support per-device keyboard event blocking

### DIFF
--- a/app/src/main/java/com/termux/x11/input/InputEventSender.java
+++ b/app/src/main/java/com/termux/x11/input/InputEventSender.java
@@ -11,12 +11,14 @@ import static com.termux.x11.input.InputStub.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import android.graphics.PointF;
+import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
 import com.termux.x11.MainActivity;
 
 import java.util.List;
+import java.util.Set;
 import java.util.TreeSet;
 
 /**
@@ -27,6 +29,12 @@ public final class InputEventSender {
     private static final int XI_TouchBegin = 18;
     private static final int XI_TouchUpdate = 19;
     private static final int XI_TouchEnd = 20;
+
+    private static final Set<Integer> TOUCH_NAV_KEYCODES = Set.of(
+        KEYCODE_BACK,
+        KEYCODE_HOME,
+        KEYCODE_APP_SWITCH
+    );
 
     private final InputStub mInjector;
     private final float[] mappedPoint = new float[2];
@@ -184,6 +192,9 @@ public final class InputEventSender {
             return true;
         }
 
+        if (shouldBlockKeyEvent(e))
+            return true;
+
         // Events received from software keyboards generate TextEvent in two
         // cases:
         //   1. This is an ACTION_MULTIPLE event.
@@ -264,5 +275,19 @@ public final class InputEventSender {
 
         // We try to send all other key codes to the host directly.
         return mInjector.sendKeyEvent(scancode, keyCode, pressed);
+    }
+
+    // Some touchpanel/touchpad hardware occasionally reports spurious key
+    // events (e.g. unexpected function keys) alongside its normal touch
+    // input, likely due to a firmware or driver quirk in the underlying
+    // input device. Filter these out to avoid having them misinterpreted
+    // as real keyboard input.
+    private boolean shouldBlockKeyEvent(KeyEvent event) {
+        InputDevice device = event.getDevice();
+        int sources = device != null ? device.getSources() : 0;
+        return (sources & InputDevice.SOURCE_KEYBOARD) != 0
+                && (sources & (InputDevice.SOURCE_TOUCHSCREEN | InputDevice.SOURCE_TOUCHPAD)) != 0
+                && (sources & InputDevice.SOURCE_STYLUS) == 0
+                && !TOUCH_NAV_KEYCODES.contains(event.getKeyCode());
     }
 }


### PR DESCRIPTION
## Problem

Some device firmware (e.g. Oplus/OnePlus touchpanel) registers non-keyboard hardware as a keyboard input source, injecting spurious key events during touch and mouse operations. These reach the X server as real key presses, causing unexpected behavior in X11 applications.

## Solution

Add a "Block spurious key events" preference screen (Settings → Keyboard) that dynamically lists all keyboard-capable non-virtual input devices. Each device has a toggle to block its key events from reaching the X server. A "Record last key event" toggle at the top temporarily shows the most recent key each device sent as a summary, to help identify misbehaving devices.

## Implementation

- `TouchInputHandler.refreshInputDevices()` caches filtered device IDs, resolved from per-device boolean preferences on each device rescan
- `InputEventSender.sendKeyEvent()` checks the cached set before any key processing
- Recording is guarded by a cached boolean, updated on preference change and device rescan
- Device listing uses standard `SwitchPreferenceCompat` + `PreferenceDataStore` patterns

## Testing

Tested on ARM64 Android 15 device with chroot XFCE via Termux:X11. Spurious F4 key events are correctly filtered when the device is toggled on. Recording toggle correctly shows the last key sent by each device. Normal keyboard and IME input unaffected.