### PR TITLE
refactor(lorie): rewrite renderer in a runtime-free C++ subset

### DIFF
--- a/lorie/src/main/cpp/lorie/buffer.h
+++ b/lorie/src/main/cpp/lorie/buffer.h
@@ -3,6 +3,10 @@
 #include <linux/ashmem.h>
 #include <android/hardware_buffer.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define STATIC_INLINE static inline __always_inline
 
 #define AHARDWAREBUFFER_FORMAT_B8G8R8A8_UNORM 5 // Stands to HAL_PIXEL_FORMAT_BGRA_8888
@@ -234,3 +238,7 @@ LorieBuffer* _Nullable LorieBufferList_findById(struct xorg_list* _Nullable list
 
 int ancil_send_fd(int sock, int fd);
 int ancil_recv_fd(int sock);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lorie/src/main/cpp/lorie/lorie.h
+++ b/lorie/src/main/cpp/lorie/lorie.h
@@ -18,6 +18,10 @@
 #define PORT 7892
 #define MAGIC "0xDEADBEEF"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct lorie_shared_server_state;
 
 void lorieConfigureNotify(int width, int height, int framerate, size_t name_size, char* name);
@@ -241,6 +245,101 @@ struct lorie_shared_server_state {
     } cursor;
 };
 
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+#include <EGL/egl.h>
+#include <GLES2/gl2.h>
+#include "list.h"
+
+struct Renderer {
+    EGLDisplay egl_display = EGL_NO_DISPLAY;
+    EGLContext ctx = EGL_NO_CONTEXT;
+    EGLSurface defaultSfc = EGL_NO_SURFACE, sfc = EGL_NO_SURFACE;
+    EGLConfig cfg = 0;
+    ANativeWindow *defaultWin = nullptr, *win = nullptr;
+    struct xorg_list addedBuffers, buffers, removedBuffers;
+    volatile jint filtering = GL_NEAREST;
+
+    volatile bool stateChanged = false, windowChanged = false;
+    struct lorie_shared_server_state* pendingState = nullptr;
+    ANativeWindow* pendingWin = nullptr;
+    volatile int viewportX = 0, viewportY = 0, viewportW = 0, viewportH = 0, expectedW = 0, expectedH = 0;
+    volatile int zoomPercent = 100;
+    float zoomSourceLeft = 0.f, zoomSourceTop = 0.f;
+    JNIEnv* rendererEnv = nullptr;
+    jclass lorieViewClass = nullptr;
+    jmethodID setRendererViewportMethod = nullptr;
+    int reportedViewportX = -1, reportedViewportY = -1, reportedViewportW = -1, reportedViewportH = -1;
+    float reportedSourceLeft = -1.f, reportedSourceTop = -1.f, reportedSourceWidth = -1.f, reportedSourceHeight = -1.f;
+
+    pthread_mutex_t stateLock;
+    // Shared with the X server so it can signal us directly. Only this thread ever waits on it, so stateLock
+    // (the companion mutex) doesn't need to be shared too.
+    pthread_cond_t* stateCond = nullptr;
+    pthread_cond_t stateChangeFinishCond;
+    pthread_spinlock_t bufferLock;
+    int stateCondFd = -1;
+    struct lorie_shared_server_state* state = nullptr;
+    struct {
+        GLuint id;
+        bool cursorChanged;
+    } cursor{};
+
+    // FBO used to blit deferred Present "copy" entries (see lorieTryScheduleGpuCopy) into the root texture.
+    GLuint gpuCopyFbo = 0;
+
+    GLuint g_texture_program = 0, gv_pos = 0, gv_coords = 0;
+    GLuint g_texture_program_bgra = 0, gv_pos_bgra = 0, gv_coords_bgra = 0;
+
+    EGLint configAttribs[13] = {
+        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+        EGL_RED_SIZE, 8,
+        EGL_GREEN_SIZE, 8,
+        EGL_BLUE_SIZE, 8,
+        EGL_ALPHA_SIZE, 0,
+        EGL_NONE
+    };
+
+    // Formerly function-local statics; moved here for the same reason as everything else above -
+    // they are per-instance state, not per-process.
+    uint64_t dstSizeLogCount = 0, srcSizeLogCount = 0;
+    uint64_t lastRequestedBufferId = 0;
+
+    void init(JNIEnv* env);
+    void* initThread(JavaVM* vm);
+    int getWakeupCondFd();
+    void setFiltering(jint f);
+    void testCapabilities(int* legacy_drawing);
+    void setSharedState(struct lorie_shared_server_state* newState);
+    void addBuffer(LorieBuffer* buf);
+    void removeBuffer(uint64_t id);
+    void removeAllBuffers();
+    void setWindow(JNIEnv* env, jobject jsfc);
+    void setViewport(int x, int y, int w, int h, int ew, int eh);
+    void setZoom(int percent);
+    void releaseWinAndSurface(ANativeWindow** anw, EGLSurface* esfc);
+    void refreshContext();
+    LorieBuffer* findBufferWithRetry(uint64_t id);
+    uint64_t applyPendingGpuCopiesLocked();
+    void applyPendingGpuCopies();
+    void redrawLocked(bool* waitingForBuffers);
+    bool shouldWait(bool* waitingForBuffers);
+    void threadLoop();
+    void bindTexture(GLuint id);
+    void reportViewport(int dstX, int dstY, int dstW, int dstH, float left, float top, float width, float height);
+    void drawRegion(GLuint id, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, uint8_t flip);
+    void drawCursor(float displayWidth, float displayHeight, float sourceLeft, float sourceTop);
+};
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static int android_to_linux_keycode[304] = {
         [ 4   /* ANDROID_KEYCODE_BACK */] = KEY_ESC,
         [ 7   /* ANDROID_KEYCODE_0 */] = KEY_0,
@@ -385,3 +484,7 @@ static int android_to_linux_keycode[304] = {
         [ 208  /* ANDROID_KEYCODE_CALENDAR */] = KEY_CALENDAR,
         [ 210  /* ANDROID_KEYCODE_CALCULATOR */] = KEY_CALC,
 };
+
+#ifdef __cplusplus
+}
+#endif

--- a/lorie/src/main/cpp/lorie/renderer.cpp
+++ b/lorie/src/main/cpp/lorie/renderer.cpp
@@ -32,7 +32,7 @@
 
 static GLuint createProgram(const char* p_vertex_source, const char* p_fragment_source);
 
-static int printEglError(char* msg, int line) {
+static void* printEglError(const char* msg, int line) {
     char descBuf[32] = {0};
     char* desc;
     int err = eglGetError();
@@ -62,10 +62,10 @@ static int printEglError(char* msg, int line) {
     if (desc)
         log("renderer: %s: %s (%s:%d)\n", msg, desc, __FILE__, line);
 
-    return 0;
+    return nullptr;
 }
 
-static inline __always_inline void vprintEglError(char* msg, int line) {
+static inline __always_inline void vprintEglError(const char* msg, int line) {
     printEglError(msg, line);
 }
 
@@ -114,45 +114,9 @@ static const char vertexShaderSrc[] =
 static const char fragmentShaderSrc[] = FRAGMENT_SHADER();
 static const char fragmentShaderBgraSrc[] = FRAGMENT_SHADER(".bgra");
 
-static EGLDisplay egl_display = EGL_NO_DISPLAY;
-static EGLContext ctx = EGL_NO_CONTEXT;
-static EGLSurface defaultSfc = EGL_NO_SURFACE, sfc = EGL_NO_SURFACE;
-static EGLConfig cfg = 0;
-static ANativeWindow *defaultWin = NULL, *win = NULL;
-static volatile struct xorg_list addedBuffers, buffers, removedBuffers;
-volatile jint filtering = GL_NEAREST;
-
-static volatile bool stateChanged = false, windowChanged = false;
-static volatile struct lorie_shared_server_state* pendingState = NULL;
-static volatile ANativeWindow* pendingWin = NULL;
-static volatile int viewportX = 0, viewportY = 0, viewportW = 0, viewportH = 0, expectedW = 0, expectedH = 0;
-static volatile int zoomPercent = 100;
-static float zoomSourceLeft = 0.f, zoomSourceTop = 0.f;
-static JNIEnv* rendererEnv = NULL;
-static jclass lorieViewClass = NULL;
-static jmethodID setRendererViewportMethod = NULL;
-static int reportedViewportX = -1, reportedViewportY = -1, reportedViewportW = -1, reportedViewportH = -1;
-static float reportedSourceLeft = -1.f, reportedSourceTop = -1.f, reportedSourceWidth = -1.f, reportedSourceHeight = -1.f;
-
-static pthread_mutex_t stateLock;
-// Shared with the X server so it can signal us directly. Only this thread ever waits on it, so stateLock
-// (the companion mutex) doesn't need to be shared too.
-static pthread_cond_t* stateCond;
-static pthread_cond_t stateChangeFinishCond;
-static pthread_spinlock_t bufferLock;
-static int stateCondFd = -1;
-static volatile struct lorie_shared_server_state* state = NULL;
-static struct {
-    GLuint id;
-    bool cursorChanged;
-} cursor;
-
-// FBO used to blit deferred Present "copy" entries (see lorieTryScheduleGpuCopy) into the root texture.
-static GLuint gpuCopyFbo = 0;
-
 // The renderer's end of activity.c's socket to the X server; used to notify it immediately when a
 // GPU copy batch finishes instead of it waiting for the next vblank-tick poll.
-extern volatile int conn_fd;
+extern "C" volatile int conn_fd;
 
 static void notifyGpuCopyDone(void) {
     if (conn_fd != -1) {
@@ -161,12 +125,11 @@ static void notifyGpuCopyDone(void) {
     }
 }
 
-GLuint g_texture_program = 0, gv_pos = 0, gv_coords = 0;
-GLuint g_texture_program_bgra = 0, gv_pos_bgra = 0, gv_coords_bgra = 0;
+// Renderer itself is declared in lorie.h so activity.cpp will be able to hold an instance
+// directly once it's converted too. For now there is still exactly one instance (g_renderer).
+static Renderer g_renderer;
 
-static void* rendererThread(void);
-
-static inline __always_inline void bindTexture(GLuint id) {
+void Renderer::bindTexture(GLuint id) {
     glBindTexture(GL_TEXTURE_2D, id);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filtering);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filtering);
@@ -174,7 +137,7 @@ static inline __always_inline void bindTexture(GLuint id) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 }
 
-static void reportRendererViewport(int dstX, int dstY, int dstW, int dstH, float left, float top, float width, float height) {
+void Renderer::reportViewport(int dstX, int dstY, int dstW, int dstH, float left, float top, float width, float height) {
     JNIEnv* env = rendererEnv;
     if (!env || !lorieViewClass || !setRendererViewportMethod)
         return;
@@ -185,10 +148,10 @@ static void reportRendererViewport(int dstX, int dstY, int dstW, int dstH, float
         reportedSourceWidth == width && reportedSourceHeight == height)
         return;
 
-    (*env)->CallStaticVoidMethod(env, lorieViewClass, setRendererViewportMethod, dstX, dstY, dstW, dstH, left, top, width, height);
-    if ((*env)->ExceptionCheck(env)) {
-        (*env)->ExceptionDescribe(env);
-        (*env)->ExceptionClear(env);
+    env->CallStaticVoidMethod(lorieViewClass, setRendererViewportMethod, dstX, dstY, dstW, dstH, left, top, width, height);
+    if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
     } else {
         reportedViewportX = dstX;
         reportedViewportY = dstY;
@@ -201,31 +164,14 @@ static void reportRendererViewport(int dstX, int dstY, int dstW, int dstH, float
     }
 }
 
-static EGLint configAttribs[] = {
-        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
-        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
-        EGL_RED_SIZE, 8,
-        EGL_GREEN_SIZE, 8,
-        EGL_BLUE_SIZE, 8,
-        EGL_ALPHA_SIZE, 0,
-        EGL_NONE
-};
-
-const EGLint ctxattribs[] = {
+static const EGLint ctxattribs[] = {
         EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE
 };
 
-static void onImageAvailable(void* context, AImageReader* reader) {
-    AImage* image = NULL;
-    if (AImageReader_acquireLatestImage(reader, &image) == AMEDIA_OK && image)
-        AImage_delete(image);
-}
-
-int rendererInitThread(void* cookie) {
-    JavaVM* vm = cookie;
-    if ((*vm)->AttachCurrentThread(vm, &rendererEnv, NULL) != JNI_OK) {
+void* Renderer::initThread(JavaVM* vm) {
+    if (vm->AttachCurrentThread(&rendererEnv, NULL) != JNI_OK) {
         log("Failed to attach renderer thread to JVM");
-        return 0;
+        return nullptr;
     }
 
     EGLint major, minor;
@@ -263,19 +209,24 @@ int rendererInitThread(void* cookie) {
     // and I am not sure all devices have configs supporting both pbuffers and regular surfaces simultaneously
     if (AImageReader_new(1, 1, AIMAGE_FORMAT_RGBA_8888, 2, &reader) != AMEDIA_OK) {
         log("Failed to initialise ImageReader");
-        return 1;
+        return nullptr;
     }
 
-    if (AImageReader_setImageListener(reader, &(AImageReader_ImageListener) { .context = NULL, .onImageAvailable = onImageAvailable }) != AMEDIA_OK) {
+    AImageReader_ImageListener listener = { .context = NULL, .onImageAvailable = [](void* context, AImageReader* reader) {
+        AImage* image = NULL;
+        if (AImageReader_acquireLatestImage(reader, &image) == AMEDIA_OK && image)
+            AImage_delete(image);
+    } };
+    if (AImageReader_setImageListener(reader, &listener) != AMEDIA_OK) {
         log("Failed to set ImageReader listener");
         AImageReader_delete(reader);
-        return 1;
+        return nullptr;
     }
 
     if (AImageReader_getWindow(reader, &defaultWin) != AMEDIA_OK) {
         log("Failed to obtain ImageReader native window");
         AImageReader_delete(reader);
-        return 1;
+        return nullptr;
     }
 
     win = defaultWin;
@@ -303,21 +254,21 @@ int rendererInitThread(void* cookie) {
     glActiveTexture(GL_TEXTURE0);
     glGenTextures(1, &cursor.id);
 
-    rendererThread();
-    return 1;
+    threadLoop();
+    return nullptr;
 }
 
-void rendererInit(JNIEnv* env) {
+void Renderer::init(JNIEnv* env) {
     pthread_t t;
     JavaVM* vm;
 
     if (ctx)
         return;
 
-    (*env)->GetJavaVM(env, &vm);
-    jclass clazz = (*env)->FindClass(env, "com/termux/x11/LorieView");
-    lorieViewClass = (*env)->NewGlobalRef(env, clazz);
-    setRendererViewportMethod = (*env)->GetStaticMethodID(env, lorieViewClass, "setRendererViewport", "(IIIIFFFF)V");
+    env->GetJavaVM(&vm);
+    jclass clazz = env->FindClass("com/termux/x11/LorieView");
+    lorieViewClass = (jclass) env->NewGlobalRef(clazz);
+    setRendererViewportMethod = env->GetStaticMethodID(lorieViewClass, "setRendererViewport", "(IIIIFFFF)V");
 
     pthread_mutex_init(&stateLock, NULL);
 
@@ -326,7 +277,7 @@ void rendererInit(JNIEnv* env) {
     pthread_condattr_init(&cond_attr);
     pthread_condattr_setpshared(&cond_attr, PTHREAD_PROCESS_SHARED);
     stateCondFd = LorieBuffer_createRegion("renderer-cond", sizeof(pthread_cond_t));
-    stateCond = stateCondFd == -1 ? MAP_FAILED : mmap(NULL, sizeof(pthread_cond_t), PROT_READ|PROT_WRITE, MAP_SHARED, stateCondFd, 0);
+    stateCond = stateCondFd == -1 ? (pthread_cond_t*) MAP_FAILED : (pthread_cond_t*) mmap(NULL, sizeof(pthread_cond_t), PROT_READ|PROT_WRITE, MAP_SHARED, stateCondFd, 0);
     if (stateCond == MAP_FAILED) {
         loge("Failed to allocate renderer wakeup cond var, aborting");
         abort();
@@ -336,25 +287,27 @@ void rendererInit(JNIEnv* env) {
     pthread_cond_init(&stateChangeFinishCond, NULL);
     pthread_spin_init(&bufferLock, false);
 
-    pthread_create(&t, NULL, (void*(*)(void*)) rendererInitThread, vm);
+    pthread_create(&t, NULL, +[](void* cookie) -> void* {
+        return g_renderer.initThread((JavaVM*) cookie);
+    }, vm);
 }
 
-int rendererGetWakeupCondFd(void) {
+int Renderer::getWakeupCondFd() {
     return stateCondFd;
 }
 
-void rendererSetFiltering(JNIEnv* env, jobject self, jint f) {
+void Renderer::setFiltering(jint f) {
     filtering = f;
 }
 
-void rendererTestCapabilities(int* legacy_drawing) {
+void Renderer::testCapabilities(int* legacy_drawing) {
     // Some devices do not support sampling from HAL_PIXEL_FORMAT_BGRA_8888, here we are checking it.
     const EGLint imageAttributes[] = {EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE};
     EGLint numConfigs;
     EGLClientBuffer clientBuffer;
     EGLImageKHR img;
     EGLint major, minor;
-    AHardwareBuffer *new = NULL;
+    AHardwareBuffer *new_ = NULL;
     int status;
     AHardwareBuffer_Desc d0 = {
             .width = 64,
@@ -376,30 +329,30 @@ void rendererTestCapabilities(int* legacy_drawing) {
     loge("Xlorie: Initialized EGL version %d.%d\n", major, minor);
     eglBindAPI(EGL_OPENGL_ES_API);
 
-    status = AHardwareBuffer_allocate(&d0, &new);
-    if (status != 0 || new == NULL) {
-        loge("Failed to allocate native buffer (%p, error %d)", new, status);
+    status = AHardwareBuffer_allocate(&d0, &new_);
+    if (status != 0 || new_ == NULL) {
+        loge("Failed to allocate native buffer (%p, error %d)", new_, status);
         loge("Forcing legacy drawing");
         *legacy_drawing = 1;
         return;
     }
 
     uint32_t *pixels;
-    if (AHardwareBuffer_lock(new, AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN | AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1, NULL, (void **) &pixels) == 0) {
+    if (AHardwareBuffer_lock(new_, AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN | AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1, NULL, (void **) &pixels) == 0) {
         pixels[0] = 0xAABBCCDD;
-        AHardwareBuffer_unlock(new, NULL);
+        AHardwareBuffer_unlock(new_, NULL);
     } else {
-        loge("Failed to lock native buffer (%p, error %d)", new, status);
+        loge("Failed to lock native buffer (%p, error %d)", new_, status);
         loge("Forcing legacy drawing");
         *legacy_drawing = 1;
-        AHardwareBuffer_release(new);
+        AHardwareBuffer_release(new_);
         return;
     }
 
-    clientBuffer = eglGetNativeClientBufferANDROID(new);
+    clientBuffer = eglGetNativeClientBufferANDROID(new_);
     if (!clientBuffer) {
         *legacy_drawing = 1;
-        AHardwareBuffer_release(new);
+        AHardwareBuffer_release(new_);
         return vprintEglError("Failed to obtain EGLClientBuffer from AHardwareBuffer, forcing legacy drawing", __LINE__);
     }
 
@@ -407,7 +360,7 @@ void rendererTestCapabilities(int* legacy_drawing) {
         loge("Failed to obtain EGLImageKHR from EGLClientBuffer");
         loge("Forcing legacy drawing");
         *legacy_drawing = 1;
-        AHardwareBuffer_release(new);
+        AHardwareBuffer_release(new_);
     } else {
         // For some reason all devices I checked had no GL_EXT_texture_format_BGRA8888 support, but some of them still provided BGRA extension.
         // EGL does not provide functions to query texture format in runtime.
@@ -452,11 +405,11 @@ void rendererTestCapabilities(int* legacy_drawing) {
         eglDestroyContext(egl_display, testctx);
         eglDestroyImageKHR(egl_display, img);
         eglDestroySurface(egl_display, checksfc);
-        AHardwareBuffer_release(new);
+        AHardwareBuffer_release(new_);
     }
 }
 
-__unused void rendererSetSharedState(struct lorie_shared_server_state* newState) {
+void Renderer::setSharedState(struct lorie_shared_server_state* newState) {
     pthread_mutex_lock(&stateLock);
     pendingState = newState;
     stateChanged = true;
@@ -468,14 +421,14 @@ __unused void rendererSetSharedState(struct lorie_shared_server_state* newState)
     pthread_mutex_unlock(&stateLock);
 }
 
-void rendererAddBuffer(LorieBuffer* buf) {
+void Renderer::addBuffer(LorieBuffer* buf) {
     pthread_spin_lock(&bufferLock);
     LorieBuffer_addToList(buf, &addedBuffers);
     pthread_cond_signal(stateCond);
     pthread_spin_unlock(&bufferLock);
 }
 
-void rendererRemoveBuffer(uint64_t id) {
+void Renderer::removeBuffer(uint64_t id) {
     pthread_spin_lock(&bufferLock);
     LorieBuffer* buf = LorieBufferList_findById(&addedBuffers, id);
     if (buf)
@@ -492,7 +445,7 @@ void rendererRemoveBuffer(uint64_t id) {
     pthread_spin_unlock(&bufferLock);
 }
 
-void rendererRemoveAllBuffers(void) {
+void Renderer::removeAllBuffers() {
     LorieBuffer *buf = NULL;
 
     pthread_spin_lock(&bufferLock);
@@ -508,7 +461,7 @@ void rendererRemoveAllBuffers(void) {
     pthread_spin_unlock(&bufferLock);
 }
 
-void rendererSetWindow(JNIEnv *env, __unused jobject thiz, jobject jsfc) {
+void Renderer::setWindow(JNIEnv *env, jobject jsfc) {
     ANativeWindow* newWin = jsfc ? ANativeWindow_fromSurface(env, jsfc) : NULL;
     if (newWin)
         ANativeWindow_acquire(newWin);
@@ -540,7 +493,7 @@ void rendererSetWindow(JNIEnv *env, __unused jobject thiz, jobject jsfc) {
     pthread_mutex_unlock(&stateLock);
 }
 
-static inline __always_inline void releaseWinAndSurface(ANativeWindow** anw, EGLSurface *esfc) {
+void Renderer::releaseWinAndSurface(ANativeWindow** anw, EGLSurface *esfc) {
     if (esfc && *esfc && *esfc != defaultSfc) {
         // Requeue the dequeued buffer, causes flickering during window reconfiguring
         eglSwapBuffers(egl_display, *esfc);
@@ -557,7 +510,7 @@ static inline __always_inline void releaseWinAndSurface(ANativeWindow** anw, EGL
     }
 }
 
-void rendererSetViewport(__unused JNIEnv *env, __unused jclass clazz, int x, int y, int w, int h, int ew, int eh) {
+void Renderer::setViewport(int x, int y, int w, int h, int ew, int eh) {
     pthread_mutex_lock(&stateLock);
     viewportX = x;
     viewportY = y;
@@ -573,7 +526,7 @@ void rendererSetViewport(__unused JNIEnv *env, __unused jclass clazz, int x, int
     pthread_mutex_unlock(&stateLock);
 }
 
-void rendererSetZoom(__unused JNIEnv *env, __unused jclass clazz, int percent) {
+void Renderer::setZoom(int percent) {
     pthread_mutex_lock(&stateLock);
     zoomPercent = percent < 100 ? 100 : (percent > 400 ? 400 : percent);
     reportedViewportX = reportedViewportY = reportedViewportW = reportedViewportH = -1;
@@ -586,7 +539,7 @@ void rendererSetZoom(__unused JNIEnv *env, __unused jclass clazz, int percent) {
     pthread_mutex_unlock(&stateLock);
 }
 
-void rendererRefreshContext(void) {
+void Renderer::refreshContext() {
     int width = pendingWin ? ANativeWindow_getWidth(pendingWin) : 0;
     int height = pendingWin ? ANativeWindow_getHeight(pendingWin) : 0;
     log("rendererSetWindow %p %d %d", pendingWin, width, height);
@@ -630,9 +583,6 @@ void rendererRefreshContext(void) {
     log("Xlorie: new surface applied: %p\n", sfc);
 }
 
-static void drawRegion(GLuint id, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, uint8_t flip);
-static void drawCursor(float displayWidth, float displayHeight, float sourceLeft, float sourceTop);
-
 // Drains the deferred GPU copy queue (filled by present_execute_copy) into the root texture via
 // an FBO. Assumes the caller holds state->lock and will flush/fence before unlocking - returns
 // the highest drained serial WITHOUT publishing it to completedSerial, since the caller must only
@@ -640,7 +590,7 @@ static void drawCursor(float displayWidth, float displayHeight, float sourceLeft
 // publishing early would let the client's next write race our still-in-flight read.
 // Looks up a registered buffer by id, waiting briefly (bounded) if it hasn't arrived over the
 // async registration socket yet instead of busy-spinning the outer loop.
-static LorieBuffer *rendererFindBufferWithRetry(uint64_t id) {
+LorieBuffer *Renderer::findBufferWithRetry(uint64_t id) {
     LorieBuffer *buf;
     int attempt;
 
@@ -665,7 +615,7 @@ static LorieBuffer *rendererFindBufferWithRetry(uint64_t id) {
     return buf;
 }
 
-static uint64_t rendererApplyPendingGpuCopiesLocked(void) {
+uint64_t Renderer::applyPendingGpuCopiesLocked() {
     bool fboSetUp = false;
     uint64_t lastSerial = 0;
     uint64_t boundDstId = 0;
@@ -676,8 +626,8 @@ static uint64_t rendererApplyPendingGpuCopiesLocked(void) {
 
     while (state->gpuCopyQueue.readIndex != state->gpuCopyQueue.writeIndex) {
         LorieGpuCopyEntry entry = state->gpuCopyQueue.entries[state->gpuCopyQueue.readIndex % LORIE_GPU_COPY_QUEUE_CAPACITY];
-        LorieBuffer *src = rendererFindBufferWithRetry(entry.srcBufferId);
-        LorieBuffer *dst = rendererFindBufferWithRetry(entry.dstBufferId);
+        LorieBuffer *src = findBufferWithRetry(entry.srcBufferId);
+        LorieBuffer *dst = findBufferWithRetry(entry.dstBufferId);
 
         if (!src)
             log("rendererApplyPendingGpuCopies: source buffer %llu not found after waiting, skipping\n", (unsigned long long) entry.srcBufferId);
@@ -706,7 +656,6 @@ static uint64_t rendererApplyPendingGpuCopiesLocked(void) {
                 // Diagnostic: GLES2 has no glGetTexLevelParameteriv, so ask the AHardwareBuffer
                 // itself what it was actually allocated as, instead of trusting our own desc.
                 {
-                    static uint64_t dstSizeLogCount = 0;
                     if (lorieDebugEnabled && (dstSizeLogCount++ & 15) == 0 && dstDesc->buffer) {
                         AHardwareBuffer_Desc realDstDesc;
                         AHardwareBuffer_describe(dstDesc->buffer, &realDstDesc);
@@ -719,7 +668,6 @@ static uint64_t rendererApplyPendingGpuCopiesLocked(void) {
 
             LorieBuffer_bindTexture(src);
             {
-                static uint64_t srcSizeLogCount = 0;
                 if (lorieDebugEnabled && (srcSizeLogCount++ & 15) == 0 && srcDesc->buffer) {
                     AHardwareBuffer_Desc realSrcDesc;
                     AHardwareBuffer_describe(srcDesc->buffer, &realSrcDesc);
@@ -765,12 +713,12 @@ static uint64_t rendererApplyPendingGpuCopiesLocked(void) {
 // Standalone entry point used by the renderer thread's main loop. Used when no redraw is going to
 // happen on this tick (rare for GPU copies in practice, since scheduling one also marks damage
 // non-empty - see lorieTryScheduleGpuCopy), so it has to take the lock and fence/unlock itself.
-static void rendererApplyPendingGpuCopies(void) {
+void Renderer::applyPendingGpuCopies() {
     uint64_t serial;
     if (!state || state->gpuCopyQueue.readIndex == state->gpuCopyQueue.writeIndex)
         return;
     lorie_mutex_lock(&state->lock, &state->lockingPid);
-    serial = rendererApplyPendingGpuCopiesLocked();
+    serial = applyPendingGpuCopiesLocked();
     if (serial) {
         EGLSync fence = eglCreateSyncKHR(egl_display, EGL_SYNC_FENCE_KHR, NULL);
         glFlush();
@@ -784,9 +732,9 @@ static void rendererApplyPendingGpuCopies(void) {
     lorie_mutex_unlock(&state->lock, &state->lockingPid);
 }
 
-void rendererRedrawLocked(bool* waitingForBuffers) {
+void Renderer::redrawLocked(bool* waitingForBuffers) {
     float xfactor = 1.f;
-    LorieBuffer_Desc *desc = NULL;
+    const LorieBuffer_Desc *desc = NULL;
     EGLSync fence;
     // The buffer will not be released until this function ends, but main thread can modify buffer list
     pthread_spin_lock(&bufferLock);
@@ -886,13 +834,13 @@ void rendererRedrawLocked(bool* waitingForBuffers) {
     } else
         zoomSourceLeft = zoomSourceTop = 0.f;
 
-    reportRendererViewport(renderViewportX, renderViewportY, renderViewportW, renderViewportH,
-                           sourceLeft, sourceTop, logicalSourceWidth, logicalSourceHeight);
+    reportViewport(renderViewportX, renderViewportY, renderViewportW, renderViewportH,
+                   sourceLeft, sourceTop, logicalSourceWidth, logicalSourceHeight);
 
     // We should signal X server to not use root window while we actively copy it
     lorie_mutex_lock(&state->lock, &state->lockingPid);
     // Share this draw's flush+fence below instead of a separate round trip per frame.
-    uint64_t gpuCopySerial = rendererApplyPendingGpuCopiesLocked();
+    uint64_t gpuCopySerial = applyPendingGpuCopiesLocked();
     state->drawRequested = FALSE;
 
     LorieBuffer_bindTexture(buffer);
@@ -945,8 +893,7 @@ void rendererRedrawLocked(bool* waitingForBuffers) {
     state->renderedFrames++;
 }
 
-static inline __always_inline bool rendererShouldWait(bool *waitingForBuffers) {
-    static uint64_t lastRequestedBufferId = 0;
+bool Renderer::shouldWait(bool *waitingForBuffers) {
     bool buffersChanged, gpuCopyPending;
     pthread_spin_lock(&bufferLock);
     buffersChanged = !xorg_list_is_empty(&addedBuffers) || !xorg_list_is_empty(&removedBuffers);
@@ -974,11 +921,11 @@ static inline __always_inline bool rendererShouldWait(bool *waitingForBuffers) {
     return true;
 }
 
-__noreturn static void* rendererThread(void) {
+void Renderer::threadLoop() {
     LorieBuffer* buf;
     bool waitingForBuffers = false;
     while (true) {
-        while (rendererShouldWait(&waitingForBuffers))
+        while (shouldWait(&waitingForBuffers))
             pthread_cond_wait(stateCond, &stateLock);
 
         if (stateChanged) {
@@ -1004,7 +951,7 @@ __noreturn static void* rendererThread(void) {
         }
 
         if (windowChanged)
-            rendererRefreshContext();
+            refreshContext();
 
         // Attach all pending buffers to GL.
         pthread_spin_lock(&bufferLock);
@@ -1023,9 +970,9 @@ __noreturn static void* rendererThread(void) {
         bool gpuCopyPending = state && state->gpuCopyQueue.readIndex != state->gpuCopyQueue.writeIndex;
         if (state && state->surfaceAvailable && !state->waitForNextFrame &&
             (state->drawRequested || state->cursor.moved || state->cursor.updated || gpuCopyPending))
-            rendererRedrawLocked(&waitingForBuffers);
+            redrawLocked(&waitingForBuffers);
         else if (gpuCopyPending)
-            rendererApplyPendingGpuCopies();
+            applyPendingGpuCopies();
 
         pthread_spin_lock(&bufferLock);
         // Remove all buffers which were attached to GL.
@@ -1090,7 +1037,7 @@ static GLuint createProgram(const char* p_vertex_source, const char* p_fragment_
     return 0;
 }
 
-static void drawRegion(GLuint id, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, uint8_t flip) {
+void Renderer::drawRegion(GLuint id, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, uint8_t flip) {
     float coords[16] = {
         x0, -y0, u0, v0,
         x1, -y0, u1, v0,
@@ -1114,7 +1061,7 @@ static void drawRegion(GLuint id, float x0, float y0, float x1, float y1, float 
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4); checkGlError();
 }
 
-__unused static void drawCursor(float displayWidth, float displayHeight, float sourceLeft, float sourceTop) {
+void Renderer::drawCursor(float displayWidth, float displayHeight, float sourceLeft, float sourceTop) {
     float x, y, w, h;
 
     if (!state->cursor.width || !state->cursor.height)
@@ -1130,3 +1077,15 @@ __unused static void drawCursor(float displayWidth, float displayHeight, float s
     glDisable(GL_BLEND);
 }
 
+// JNI-facing entry points; these are the only places g_renderer is referenced by name.
+void rendererInit(JNIEnv* env) { g_renderer.init(env); }
+int rendererGetWakeupCondFd(void) { return g_renderer.getWakeupCondFd(); }
+void rendererSetFiltering(JNIEnv* env, jobject self, jint filtering) { g_renderer.setFiltering(filtering); }
+void rendererTestCapabilities(int* legacy_drawing) { g_renderer.testCapabilities(legacy_drawing); }
+void rendererSetSharedState(struct lorie_shared_server_state* newState) { g_renderer.setSharedState(newState); }
+void rendererAddBuffer(LorieBuffer* buf) { g_renderer.addBuffer(buf); }
+void rendererRemoveBuffer(uint64_t id) { g_renderer.removeBuffer(id); }
+void rendererRemoveAllBuffers(void) { g_renderer.removeAllBuffers(); }
+void rendererSetWindow(JNIEnv *env, jobject thiz, jobject sfc) { g_renderer.setWindow(env, sfc); }
+void rendererSetViewport(JNIEnv *env, jclass clazz, int x, int y, int w, int h, int ew, int eh) { g_renderer.setViewport(x, y, w, h, ew, eh); }
+void rendererSetZoom(JNIEnv *env, jclass clazz, int percent) { g_renderer.setZoom(percent); }

--- a/lorie/src/main/cpp/recipes/xserver.cmake
+++ b/lorie/src/main/cpp/recipes/xserver.cmake
@@ -58,9 +58,16 @@ set(inc "${CMAKE_CURRENT_BINARY_DIR}"
         "xserver/glx"
         "xserver/exa")
 
-set(compile_options
+# C-only: common_compile_options is built from check_c_compiler_flag, and several of its
+# flags (-Wstrict-prototypes, -Wmissing-prototypes, -Wnested-externs, -Wbad-function-cast,
+# -Wold-style-definition) are meaningless or invalid for C++; -std=gnu99 is a C standard version.
+set(c_only_compile_options
         ${common_compile_options}
-        "-std=gnu99"
+        "-std=gnu99")
+
+# Applies to both languages: macros and flags that affect header/struct-layout consistency or
+# code generation, not C-vs-C++ syntax.
+set(compile_options
         "-DHAVE_DIX_CONFIG_H"
         "-fno-strict-aliasing"
         "-fvisibility=hidden"
@@ -83,12 +90,12 @@ set(DIX_SOURCES
 list(TRANSFORM DIX_SOURCES PREPEND "xserver/dix/")
 add_library(xserver_dix STATIC ${DIX_SOURCES})
 target_include_directories(xserver_dix PRIVATE ${inc})
-target_compile_options(xserver_dix PRIVATE ${compile_options})
+target_compile_options(xserver_dix PRIVATE ${c_only_compile_options} ${compile_options})
 
 add_library(xserver_main STATIC
         "xserver/dix/stubmain.c")
 target_include_directories(xserver_main PRIVATE ${inc})
-target_compile_options(xserver_main PRIVATE ${compile_options})
+target_compile_options(xserver_main PRIVATE ${c_only_compile_options} ${compile_options})
 
 file(GENERATE
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/drm_fourcc.h"
@@ -106,7 +113,7 @@ add_library(xserver_dri3 STATIC
         "xserver/dri3/dri3_request.c"
         "xserver/dri3/dri3_screen.c")
 target_include_directories(xserver_dri3 PRIVATE ${inc})
-target_compile_options(xserver_dri3 PRIVATE ${compile_options})
+target_compile_options(xserver_dri3 PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(FB_SOURCES
         fballpriv.c fbarc.c fbbits.c fbblt.c fbbltone.c fbcmap_mi.c fbcopy.c fbfill.c fbfillrect.c
@@ -115,7 +122,7 @@ set(FB_SOURCES
 list(TRANSFORM FB_SOURCES PREPEND "xserver/fb/")
 add_library(xserver_fb STATIC ${FB_SOURCES})
 target_include_directories(xserver_fb PRIVATE ${inc})
-target_compile_options(xserver_fb PRIVATE ${compile_options})
+target_compile_options(xserver_fb PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(MI_SOURCES
         miarc.c mibitblt.c micmap.c micopy.c midash.c midispcur.c mieq.c miexpose.c mifillarc.c
@@ -125,7 +132,7 @@ set(MI_SOURCES
 list(TRANSFORM MI_SOURCES PREPEND "xserver/mi/")
 add_library(xserver_mi STATIC ${MI_SOURCES})
 target_include_directories(xserver_mi PRIVATE ${inc})
-target_compile_options(xserver_mi PRIVATE ${compile_options})
+target_compile_options(xserver_mi PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(OS_SOURCES
         WaitFor.c access.c auth.c backtrace.c client.c connection.c inputthread.c io.c mitauth.c
@@ -135,31 +142,31 @@ list(TRANSFORM OS_SOURCES PREPEND "xserver/os/")
 add_library(xserver_os STATIC ${OS_SOURCES})
 target_include_directories(xserver_os PRIVATE ${inc})
 target_link_libraries(xserver_os PRIVATE md Xdmcp Xau tirpc)
-target_compile_options(xserver_os PRIVATE ${compile_options} "-DCLIENTIDS")
+target_compile_options(xserver_os PRIVATE ${c_only_compile_options} ${compile_options} "-DCLIENTIDS")
 
 set(COMPOSITE_SOURCES compalloc.c compext.c compinit.c compoverlay.c compwindow.c)
 list(TRANSFORM COMPOSITE_SOURCES PREPEND "xserver/composite/")
 add_library(xserver_composite STATIC ${COMPOSITE_SOURCES})
 target_include_directories(xserver_composite PRIVATE ${inc})
-target_compile_options(xserver_composite PRIVATE ${compile_options})
+target_compile_options(xserver_composite PRIVATE ${c_only_compile_options} ${compile_options})
 
 add_library(xserver_damageext STATIC "xserver/damageext/damageext.c")
 target_include_directories(xserver_damageext PRIVATE ${inc})
-target_compile_options(xserver_damageext PRIVATE ${compile_options})
+target_compile_options(xserver_damageext PRIVATE ${c_only_compile_options} ${compile_options})
 
 add_library(xserver_dbe STATIC "xserver/dbe/dbe.c" "xserver/dbe/midbe.c")
 target_include_directories(xserver_dbe PRIVATE ${inc})
-target_compile_options(xserver_dbe PRIVATE ${compile_options})
+target_compile_options(xserver_dbe PRIVATE ${c_only_compile_options} ${compile_options})
 
 add_library(xserver_miext_damage STATIC "xserver/miext/damage/damage.c")
 target_include_directories(xserver_miext_damage PRIVATE ${inc})
-target_compile_options(xserver_miext_damage PRIVATE ${compile_options})
+target_compile_options(xserver_miext_damage PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(MIEXT_SYNC_SOURCES misync.c misyncfd.c misyncshm.c)
 list(TRANSFORM MIEXT_SYNC_SOURCES PREPEND "xserver/miext/sync/")
 add_library(xserver_miext_sync STATIC ${MIEXT_SYNC_SOURCES})
 target_include_directories(xserver_miext_sync PRIVATE ${inc})
-target_compile_options(xserver_miext_sync PRIVATE ${compile_options})
+target_compile_options(xserver_miext_sync PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(PRESENT_SOURCES
         present.c present_event.c present_execute.c present_fake.c present_fence.c present_notify.c
@@ -167,7 +174,7 @@ set(PRESENT_SOURCES
 list(TRANSFORM PRESENT_SOURCES PREPEND "xserver/present/")
 add_library(xserver_present STATIC ${PRESENT_SOURCES})
 target_include_directories(xserver_present PRIVATE ${inc})
-target_compile_options(xserver_present PRIVATE ${compile_options})
+target_compile_options(xserver_present PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(RANDR_SOURCES
         randr.c rrcrtc.c rrdispatch.c rrinfo.c rrlease.c rrmode.c rrmonitor.c rroutput.c rrpointer.c
@@ -176,11 +183,11 @@ set(RANDR_SOURCES
 list(TRANSFORM RANDR_SOURCES PREPEND "xserver/randr/")
 add_library(xserver_randr STATIC ${RANDR_SOURCES})
 target_include_directories(xserver_randr PRIVATE ${inc})
-target_compile_options(xserver_randr PRIVATE ${compile_options})
+target_compile_options(xserver_randr PRIVATE ${c_only_compile_options} ${compile_options})
 
 add_library(xserver_record STATIC xserver/record/record.c xserver/record/set.c)
 target_include_directories(xserver_record PRIVATE ${inc})
-target_compile_options(xserver_record PRIVATE ${compile_options})
+target_compile_options(xserver_record PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(RENDER_SOURCES
         animcur.c filter.c glyph.c matrix.c miindex.c mipict.c mirect.c mitrap.c mitri.c picture.c
@@ -188,13 +195,13 @@ set(RENDER_SOURCES
 list(TRANSFORM RENDER_SOURCES PREPEND "xserver/render/")
 add_library(xserver_render STATIC ${RENDER_SOURCES})
 target_include_directories(xserver_render PRIVATE ${inc})
-target_compile_options(xserver_render PRIVATE ${compile_options})
+target_compile_options(xserver_render PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(XFIXES_SOURCES cursor.c disconnect.c region.c saveset.c select.c xfixes.c)
 list(TRANSFORM XFIXES_SOURCES PREPEND "xserver/xfixes/")
 add_library(xserver_xfixes STATIC ${XFIXES_SOURCES})
 target_include_directories(xserver_xfixes PRIVATE ${inc})
-target_compile_options(xserver_xfixes PRIVATE ${compile_options})
+target_compile_options(xserver_xfixes PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(XKB_SOURCES
         ddxBeep.c ddxCtrls.c ddxLEDs.c ddxLoad.c maprules.c xkmread.c xkbtext.c xkbfmisc.c xkbout.c
@@ -203,13 +210,13 @@ set(XKB_SOURCES
 list(TRANSFORM XKB_SOURCES PREPEND "xserver/xkb/")
 add_library(xserver_xkb STATIC ${XKB_SOURCES})
 target_include_directories(xserver_xkb PRIVATE ${inc})
-target_compile_options(xserver_xkb PRIVATE ${compile_options} "-DXkbFreeGeomOverlayKeys=XkbFreeGeomOverlayKeysInternal")
+target_compile_options(xserver_xkb PRIVATE ${c_only_compile_options} ${compile_options} "-DXkbFreeGeomOverlayKeys=XkbFreeGeomOverlayKeysInternal")
 
 set(XKB_STUBS_SOURCES ddxKillSrv.c ddxPrivate.c ddxVT.c)
 list(TRANSFORM XKB_STUBS_SOURCES PREPEND "xserver/xkb/")
 add_library(xserver_xkb_stubs STATIC ${XKB_STUBS_SOURCES})
 target_include_directories(xserver_xkb_stubs PRIVATE ${inc})
-target_compile_options(xserver_xkb_stubs PRIVATE ${compile_options})
+target_compile_options(xserver_xkb_stubs PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(XEXT_SOURCES
         bigreq.c geext.c shape.c sleepuntil.c sync.c xcmisc.c xtest.c dpms.c shm.c hashtable.c
@@ -218,7 +225,7 @@ set(XEXT_SOURCES
 list(TRANSFORM XEXT_SOURCES PREPEND "xserver/Xext/")
 add_library(xserver_xext STATIC ${XEXT_SOURCES})
 target_include_directories(xserver_xext PRIVATE ${inc})
-target_compile_options(xserver_xext PRIVATE ${compile_options})
+target_compile_options(xserver_xext PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(XI_SOURCES
         allowev.c chgdctl.c chgfctl.c chgkbd.c chgkmap.c chgprop.c chgptr.c closedev.c devbell.c
@@ -231,11 +238,11 @@ set(XI_SOURCES
 list(TRANSFORM XI_SOURCES PREPEND "xserver/Xi/")
 add_library(xserver_xi STATIC ${XI_SOURCES})
 target_include_directories(xserver_xi PRIVATE ${inc})
-target_compile_options(xserver_xi PRIVATE ${compile_options})
+target_compile_options(xserver_xi PRIVATE ${c_only_compile_options} ${compile_options})
 
 add_library(xserver_xi_stubs STATIC "xserver/Xi/stubs.c")
 target_include_directories(xserver_xi_stubs PRIVATE ${inc})
-target_compile_options(xserver_xi_stubs PRIVATE ${compile_options})
+target_compile_options(xserver_xi_stubs PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(GLX_SOURCES
         glxext.c indirect_dispatch.c indirect_dispatch_swap.c indirect_reqsize.c indirect_size_get.c
@@ -246,7 +253,7 @@ set(GLX_SOURCES
 list(TRANSFORM GLX_SOURCES PREPEND "xserver/glx/")
 add_library(xserver_glx STATIC ${GLX_SOURCES} "${CMAKE_CURRENT_BINARY_DIR}/xserver/GL/gl.h")
 target_include_directories(xserver_glx PRIVATE ${inc})
-target_compile_options(xserver_glx PRIVATE ${compile_options})
+target_compile_options(xserver_glx PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(EXA_SOURCES
         exa.c exa_classic.c exa_migration_classic.c exa_driver.c exa_mixed.c exa_migration_mixed.c
@@ -254,14 +261,14 @@ set(EXA_SOURCES
 list(TRANSFORM EXA_SOURCES PREPEND "xserver/exa/")
 add_library(xserver_exa STATIC ${EXA_SOURCES})
 target_include_directories(xserver_exa PRIVATE ${inc})
-target_compile_options(xserver_exa PRIVATE ${compile_options})
+target_compile_options(xserver_exa PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(GLXVND_SOURCES
         vndcmds.c vndext.c vndservermapping.c vndservervendor.c)
 list(TRANSFORM GLXVND_SOURCES PREPEND "xserver/glx/")
 add_library(xserver_glxvnd STATIC ${GLXVND_SOURCES})
 target_include_directories(xserver_glxvnd PRIVATE ${inc})
-target_compile_options(xserver_glxvnd PRIVATE ${compile_options})
+target_compile_options(xserver_glxvnd PRIVATE ${c_only_compile_options} ${compile_options})
 
 set(XSERVER_LIBS tirpc Xdmcp Xau pixman Xfont2 fontenc GLESv2 xshmfence xkbcomp)
 foreach (part glx glxvnd fb mi dix composite damageext dbe randr miext_damage render present xext
@@ -279,12 +286,14 @@ add_library(Xlorie SHARED
         "lorie/InitOutput.c"
         "lorie/InitInput.c"
         "lorie/InputXKB.c"
-        "lorie/renderer.c"
+        "lorie/renderer.cpp"
         "lorie/buffer.c"
         "lorie/activity.c")
 target_include_directories(Xlorie PRIVATE ${inc} "libxcvt/include")
-target_link_options(Xlorie PRIVATE "-Wl,--as-needed" "-Wl,--no-undefined" "-fvisibility=hidden")
+# -nostdlib++ keeps this shared object free of any libc++ dependency; renderer.cpp is restricted
+# to a runtime-free subset of C++ (no exceptions, no RTTI, no STL) to make that possible.
+target_link_options(Xlorie PRIVATE "-Wl,--as-needed" "-Wl,--no-undefined" "-fvisibility=hidden" "-nostdlib++")
 target_link_libraries(Xlorie "-Wl,--whole-archive" ${XSERVER_LIBS} "-Wl,--no-whole-archive" android mediandk log m z EGL GLESv2)
-target_compile_options(Xlorie PRIVATE ${compile_options})
+target_compile_options(Xlorie PRIVATE ${compile_options} "$<$<COMPILE_LANGUAGE:C>:${c_only_compile_options}>" "$<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions;-fno-rtti>")
 target_apply_patch(Xlorie "${CMAKE_CURRENT_SOURCE_DIR}/xserver" "${CMAKE_CURRENT_SOURCE_DIR}/patches/xserver.patch")
 target_apply_patch(Xlorie "${CMAKE_CURRENT_SOURCE_DIR}/libepoxy" "${CMAKE_CURRENT_SOURCE_DIR}/patches/libepoxy.patch")


### PR DESCRIPTION
First step towards multi-instance support (multiple X servers/windows at once): renderer state currently lives in file-scope C globals, which assume exactly one renderer per process. This moves it into a single `Renderer` object instead, so it can eventually become one-per-instance — no functional change here, just groundwork.

Written in a runtime-free subset of C++ (no exceptions, no RTTI, no STL, `-nostdlib++`), so it adds no `libc++` dependency to `Xlorie.so`.