### PR TITLE
build(lorie): skip recompiling native code when a host app already built it

### DIFF
--- a/.github/termux-app-integration/termux-app.patch
+++ b/.github/termux-app-integration/termux-app.patch
@@ -1,16 +1,32 @@
 diff --git a/app/build.gradle b/app/build.gradle
-index b3168f09..04d4a309 100644
+index b3168f09..9bfa11b0 100644
 --- a/app/build.gradle
 +++ b/app/build.gradle
-@@ -29,6 +29,7 @@ android {
+@@ -3,12 +3,13 @@ plugins {
+ }
+ 
+ def apkVersionTag = System.getenv("TERMUX_APK_VERSION_TAG") ?: ""
++apply from: new File(rootDir, "../lorie/version.gradle")
+ 
+ android {
+     namespace "com.termux"
+ 
+     compileSdkVersion project.properties.compileSdkVersion.toInteger()
+-    ndkVersion = System.getenv("JITPACK_NDK_VERSION") ?: project.properties.ndkVersion
++    ndkVersion = System.getenv("JITPACK_NDK_VERSION") ?: termuxX11NdkVersion
+     def appVersionName = System.getenv("TERMUX_APP_VERSION_NAME") ?: ""
+     def splitAPKsForDebugBuilds = System.getenv("TERMUX_SPLIT_APKS_FOR_DEBUG_BUILDS") ?: "1"
+     def splitAPKsForReleaseBuilds = System.getenv("TERMUX_SPLIT_APKS_FOR_RELEASE_BUILDS") ?: "0" // F-Droid does not support split APKs #1904
+@@ -29,6 +30,8 @@ android {
  
          implementation project(":terminal-view")
          implementation project(":termux-shared")
++        rootProject.ext.prebuiltJniLibsDir = new File(rootDir, "../lorie/build/intermediates/stripped_native_libs/debug/stripDebugDebugSymbols/out/lib")
 +        implementation project(':lorie')
      }
  
      defaultConfig {
-@@ -39,6 +40,7 @@ android {
+@@ -39,6 +42,7 @@ android {
  
          if (appVersionName) versionName = appVersionName
          validateVersionName(versionName)
@@ -18,7 +34,7 @@ index b3168f09..04d4a309 100644
  
          manifestPlaceholders.TERMUX_PACKAGE_NAME = "com.termux"
          manifestPlaceholders.TERMUX_APP_NAME = "Termux"
-@@ -110,7 +112,7 @@ android {
+@@ -110,7 +114,7 @@ android {
  
      packagingOptions {
          jniLibs {

--- a/lorie-app/build.gradle
+++ b/lorie-app/build.gradle
@@ -4,6 +4,7 @@ apply from: '../lorie/version.gradle'
 android {
     namespace 'com.termux.x11.app'
     compileSdkVersion 34
+    ndkVersion termuxX11NdkVersion
     defaultConfig {
         applicationId "com.termux.x11"
         minSdkVersion 26

--- a/lorie/build.gradle
+++ b/lorie/build.gradle
@@ -20,15 +20,12 @@ if (hostProjects.size() > 1)
     throw new GradleException("Multiple application modules depend on :${project.name} (${hostProjects.collect { it.path }}); cannot determine which one is the real host")
 def hostProject = hostProjects[0]
 def hostApplicationId = hostProject.android.defaultConfig.applicationId ?: hostProject.android.namespace
-// ndkVersion isn't inherited from the host module; use its value when set,
-// otherwise fall back to a known 16 KB-page-aligning NDK.
-def hostNdkVersion = hostProject.android.ndkVersion ?: "29.0.14206865"
 
 android {
     namespace 'com.termux.x11'
     //noinspection GrDeprecatedAPIUsage
     compileSdkVersion 34
-    ndkVersion hostNdkVersion
+    ndkVersion termuxX11NdkVersion
     defaultConfig {
         minSdkVersion 26
         targetSdkVersion 34
@@ -41,7 +38,16 @@ android {
 
     compileOptions.sourceCompatibility JavaVersion.VERSION_1_9
     compileOptions.targetCompatibility JavaVersion.VERSION_1_9
-    externalNativeBuild.cmake.path "src/main/cpp/CMakeLists.txt"
+    if (rootProject.ext.has('prebuiltJniLibsDir')) {
+        // Consumer already built us once and pointed us at those .so's, so we don't have to run
+        // CMake (and its own separate CMake config/cache) a second time for the same source.
+        def libsDir = file(rootProject.ext.prebuiltJniLibsDir)
+        if (!libsDir.directory || !libsDir.list())
+            throw new GradleException("prebuiltJniLibsDir '${libsDir}' doesn't exist or is empty; was :lorie-app built first?")
+        sourceSets.main.jniLibs.srcDirs += libsDir
+    } else {
+        externalNativeBuild.cmake.path "src/main/cpp/CMakeLists.txt"
+    }
     packagingOptions.jniLibs.useLegacyPackaging false
     buildFeatures.aidl true
     buildFeatures.buildConfig true

--- a/lorie/version.gradle
+++ b/lorie/version.gradle
@@ -3,3 +3,9 @@ ext.termuxX11VersionName = {
     def version = "1.03.01"
     "${version}-${commit.length() == 1 ? "nongit" : commit}-${(new Date()).format("dd.MM.yy")}"
 }()
+
+// Single source of truth for the NDK version. Anything building :lorie (this repo's own
+// lorie-app, or a host app integrating it) should read this instead of letting AGP pick its
+// own default, otherwise :lorie's CMake config differs between them and its native code gets
+// compiled twice.
+ext.termuxX11NdkVersion = "29.0.14206865"


### PR DESCRIPTION
Single source of truth for ndkVersion (lorie/version.gradle), shared between lorie-app and the termux-app integration patch. On top of that, :lorie now skips CMake entirely and reuses the already-built .so's when the consumer points it at them, instead of recompiling the whole native tree a second time in the termux-app-integrated CI step.