### PR TITLE
refactor(lorie): rewrite activity.c in a runtime-free C++ subset

### DIFF
--- a/lorie/src/main/cpp/lorie/activity.cpp
+++ b/lorie/src/main/cpp/lorie/activity.cpp
@@ -21,6 +21,7 @@
 #pragma ide diagnostic ignored "cppcoreguidelines-narrowing-conversions"
 #pragma ide diagnostic ignored "ConstantFunctionResult"
 #define log(prio, ...) __android_log_print(ANDROID_LOG_ ## prio, "LorieNative", __VA_ARGS__)
+#define sendEvent(...) do { if (conn_fd != -1) { lorieEvent e = { __VA_ARGS__ }; write(conn_fd, &e, sizeof(e)); } } while (0)
 
 extern volatile int conn_fd; // The only variable from shared with X server code.
 bool lorieDebugEnabled = false;
@@ -43,6 +44,7 @@ static struct {
 
 static JNIEnv *guienv = NULL; // Must be used only in GUI thread.
 static jobject globalThiz = NULL;
+static Renderer g_renderer;
 
 static jclass FindClassOrDie(JNIEnv *env, const char* name) {
     jclass clazz = env->FindClass(name);
@@ -124,7 +126,7 @@ static void nativeInit(JNIEnv *env, jobject thiz) {
         MainActivity.resetIme = FindMethodOrDie(env, env->GetObjectClass(thiz), "resetIme", "()V", JNI_FALSE);
     }
 
-    rendererInit(env);
+    g_renderer.init(env);
 
     env->GetJavaVM(&vm);
     vm->AttachCurrentThread(&guienv, NULL);
@@ -144,8 +146,8 @@ static int xcallback(int fd, int events, __unused void* data) {
         ALooper_removeFd(ALooper_forThread(), fd);
         close(conn_fd);
         conn_fd = -1;
-        rendererSetSharedState(NULL);
-        rendererRemoveAllBuffers();
+        g_renderer.setSharedState(NULL);
+        g_renderer.removeAllBuffers();
         log(DEBUG, "disconnected");
         return 1;
     }
@@ -191,7 +193,7 @@ static int xcallback(int fd, int events, __unused void* data) {
                         state = NULL;
                     }
 
-                    rendererSetSharedState(state);
+                    g_renderer.setSharedState(state);
 
                     close(stateFd); // Closing file descriptor does not unmmap shared memory fragment.
                     break;
@@ -202,11 +204,11 @@ static int xcallback(int fd, int events, __unused void* data) {
                     LorieBuffer_recvHandleFromUnixSocket(conn_fd, &buffer);
                     desc = LorieBuffer_description(buffer);
                     log(INFO, "Received shared buffer width %d stride %d height %d format %d type %d id %llu", desc->width, desc->stride, desc->height, desc->format, desc->type, desc->id);
-                    rendererAddBuffer(buffer);
+                    g_renderer.addBuffer(buffer);
                     break;
                 }
                 case EVENT_REMOVE_BUFFER: {
-                    rendererRemoveBuffer(e.removeBuffer.id);
+                    g_renderer.removeBuffer(e.removeBuffer.id);
                     break;
                 }
                 case EVENT_WINDOW_FOCUS_CHANGED: {
@@ -227,8 +229,8 @@ static void connect_(__unused JNIEnv* env, __unused jobject cls, jint fd) {
     if (conn_fd != -1) {
         ALooper_removeFd(ALooper_forThread(), conn_fd);
         close(conn_fd);
-        rendererSetSharedState(NULL);
-        rendererRemoveAllBuffers();
+        g_renderer.setSharedState(NULL);
+        g_renderer.removeAllBuffers();
         log(DEBUG, "disconnected");
     }
 
@@ -238,14 +240,10 @@ static void connect_(__unused JNIEnv* env, __unused jobject cls, jint fd) {
         // Give the X server our renderer wakeup cond var fd, resent on every reconnect.
         lorieEvent e = { .type = EVENT_RENDERER_WAKEUP_COND };
         write(conn_fd, &e, sizeof(e));
-        ancil_send_fd(conn_fd, rendererGetWakeupCondFd());
+        ancil_send_fd(conn_fd, g_renderer.getWakeupCondFd());
 
         log(DEBUG, "XCB connection is successfull");
     }
-}
-
-static jboolean connected(__unused JNIEnv* env,__unused jclass clazz) {
-    return conn_fd != -1;
 }
 
 static void startLogcat(JNIEnv *env, __unused jobject cls, jint fd) {
@@ -266,87 +264,6 @@ static void startLogcat(JNIEnv *env, __unused jobject cls, jint fd) {
             log(ERROR, "exec logcat: %s", strerror(errno));
             env->FatalError("Exiting");
     }
-}
-
-static void setClipboardSyncEnabled(__unused JNIEnv* env, __unused jobject cls, jboolean enable, __unused jboolean ignored) {
-    if (conn_fd != -1) {
-        lorieEvent e = { .clipboardEnable = { .t = EVENT_CLIPBOARD_ENABLE, .enable = enable } };
-        write(conn_fd, &e, sizeof(e));
-    }
-}
-
-static void sendClipboardAnnounce(__unused JNIEnv *env, __unused jobject thiz) {
-    if (conn_fd != -1) {
-        lorieEvent e = { .type = EVENT_CLIPBOARD_ANNOUNCE };
-        write(conn_fd, &e, sizeof(e));
-    }
-}
-
-static void sendClipboardEvent(JNIEnv *env, __unused jobject thiz, jbyteArray text) {
-    if (conn_fd != -1 && text) {
-        jsize length = env->GetArrayLength(text);
-        jbyte* str = env->GetByteArrayElements(text, NULL);
-        lorieEvent e = { .clipboardSend = { .t = EVENT_CLIPBOARD_SEND, .count = (uint32_t) length } };
-        write(conn_fd, &e, sizeof(e));
-        write(conn_fd, str, length);
-        env->ReleaseByteArrayElements(text, str, JNI_ABORT);
-    }
-}
-
-static void sendWindowChange(__unused JNIEnv* env, __unused jobject cls, jint width, jint height, jint framerate, jstring jname) {
-    if (conn_fd != -1) {
-        const char *name = (!jname || width <= 0 || height <= 0) ? NULL : env->GetStringUTFChars(jname, JNI_FALSE);
-        lorieEvent e = { .screenSize = { .t = EVENT_SCREEN_SIZE, .width = (uint16_t) width, .height = (uint16_t) height, .framerate = (uint16_t) framerate, .name_size = (name ? strlen(name) : 0) } };
-        write(conn_fd, &e, sizeof(e));
-        if (name) {
-            write(conn_fd, name, strlen(name));
-            env->ReleaseStringUTFChars(jname, name);
-        }
-    }
-}
-
-static void sendMouseEvent(__unused JNIEnv* env, __unused jobject cls, jfloat x, jfloat y, jint which_button, jboolean button_down, jboolean relative) {
-    if (conn_fd != -1) {
-        if (which_button > 0)
-            env->CallVoidMethod(globalThiz, MainActivity.resetIme);
-        lorieEvent e = { .mouse = { .t = EVENT_MOUSE, .x = x, .y = y, .detail = (uint8_t) which_button, .down = button_down, .relative = relative } };
-        write(conn_fd, &e, sizeof(e));
-    }
-}
-
-static void sendTouchEvent(__unused JNIEnv* env, __unused jobject cls, jint action, jint id, jint x, jint y) {
-    if (conn_fd != -1 && action != -1) {
-        lorieEvent e = { .touch = { .t = EVENT_TOUCH, .type = (uint16_t) action, .id = (uint16_t) id, .x = (uint16_t) x, .y = (uint16_t) y } };
-        write(conn_fd, &e, sizeof(e));
-    }
-}
-
-static void sendStylusEvent(__unused JNIEnv *env, __unused jobject thiz, jfloat x, jfloat y,
-                            jint pressure, jint tilt_x, jint tilt_y,
-                            jint orientation, jint buttons, jboolean eraser, jboolean mouse) {
-    if (conn_fd != -1) {
-        env->CallVoidMethod(globalThiz, MainActivity.resetIme);
-        lorieEvent e = { .stylus = { .t = EVENT_STYLUS, .x = x, .y = y, .pressure = (uint16_t) pressure, .tilt_x = (int8_t) tilt_x, .tilt_y = (int8_t) tilt_y, .orientation = (int16_t) orientation, .buttons = (uint8_t) buttons, .eraser = eraser, .mouse = mouse } };
-        write(conn_fd, &e, sizeof(e));
-    }
-}
-
-static void requestStylusEnabled(__unused JNIEnv *env, __unused jclass clazz, jboolean enabled) {
-    if (conn_fd != -1) {
-        lorieEvent e = { .stylusEnable = { .t = EVENT_STYLUS_ENABLE, .enable = enabled } };
-        write(conn_fd, &e, sizeof(e));
-    }
-}
-
-static jboolean sendKeyEvent(__unused JNIEnv* env, __unused jobject cls, jint scan_code, jint key_code, jboolean key_down) {
-    if (conn_fd != -1) {
-        int code = (scan_code) ?: android_to_linux_keycode[key_code];
-        log(DEBUG, "Sending key: %d (%d %d %d)", code + 8, scan_code, key_code, key_down);
-        lorieEvent e = { .key = { .t = EVENT_KEY, .key = (uint16_t) (code + 8), .state = key_down } };
-        write(conn_fd, &e, sizeof(e));
-    }
-
-    return true;
 }
 
 static void sendTextEvent(JNIEnv *env, __unused jobject thiz, jbyteArray text) {
@@ -389,22 +306,76 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *vm, __unused void *reserved) {
     JNIEnv* env;
     static JNINativeMethod methods[] = {
             {"nativeInit", "()V", (void *)&nativeInit},
-            {"surfaceChanged", "(Landroid/view/Surface;)V", (void *)&rendererSetWindow},
-            {"setViewport", "(IIIIII)V", (void *)&rendererSetViewport},
-            {"setRendererZoom", "(I)V", (void *)&rendererSetZoom},
-            {"setFiltering", "(I)V", (void *)&rendererSetFiltering},
+            {"surfaceChanged", "(Landroid/view/Surface;)V", (void *) +[](JNIEnv *env, __unused jobject thiz, jobject sfc) {
+                g_renderer.setWindow(env, sfc);
+            }},
+            {"setViewport", "(IIIIII)V", (void *) +[](__unused JNIEnv *env, __unused jclass clazz, jint x, jint y, jint w, jint h, jint ew, jint eh) {
+                g_renderer.setViewport(x, y, w, h, ew, eh);
+            }},
+            {"setRendererZoom", "(I)V", (void *) +[](__unused JNIEnv *env, __unused jclass clazz, jint percent) {
+                g_renderer.setZoom(percent);
+            }},
+            {"setFiltering", "(I)V", (void *) +[](__unused JNIEnv* env, __unused jobject self, jint filtering) {
+                g_renderer.setFiltering(filtering);
+            }},
             {"connect", "(I)V", (void *)&connect_},
-            {"connected", "()Z", (void *)&connected},
+            {"connected", "()Z", (void *) +[](__unused JNIEnv* env, __unused jclass clazz) -> jboolean {
+                return conn_fd != -1;
+            }},
             {"startLogcat", "(I)V", (void *)&startLogcat},
-            {"setClipboardSyncEnabled", "(ZZ)V", (void *)&setClipboardSyncEnabled},
-            {"sendClipboardAnnounce", "()V", (void *)&sendClipboardAnnounce},
-            {"sendClipboardEvent", "([B)V", (void *)&sendClipboardEvent},
-            {"sendWindowChange", "(IIILjava/lang/String;)V", (void *)&sendWindowChange},
-            {"sendMouseEvent", "(FFIZZ)V", (void *)&sendMouseEvent},
-            {"sendTouchEvent", "(IIII)V", (void *)&sendTouchEvent},
-            {"sendStylusEvent", "(FFIIIIIZZ)V", (void *)&sendStylusEvent},
-            {"requestStylusEnabled", "(Z)V", (void *)&requestStylusEnabled},
-            {"sendKeyEvent", "(IIZI)Z", (void *)&sendKeyEvent},
+            {"setClipboardSyncEnabled", "(ZZ)V", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jboolean enable, __unused jboolean ignored) {
+                sendEvent(.clipboardEnable = { .t = EVENT_CLIPBOARD_ENABLE, .enable = enable });
+            }},
+            {"sendClipboardAnnounce", "()V", (void *) +[](__unused JNIEnv *env, __unused jobject thiz) {
+                sendEvent(.type = EVENT_CLIPBOARD_ANNOUNCE);
+            }},
+            {"sendClipboardEvent", "([B)V", (void *) +[](JNIEnv *env, __unused jobject thiz, jbyteArray text) {
+                if (conn_fd != -1 && text) {
+                    jsize length = env->GetArrayLength(text);
+                    jbyte* str = env->GetByteArrayElements(text, NULL);
+                    sendEvent(.clipboardSend = { .t = EVENT_CLIPBOARD_SEND, .count = (uint32_t) length });
+                    write(conn_fd, str, length);
+                    env->ReleaseByteArrayElements(text, str, JNI_ABORT);
+                }
+            }},
+            {"sendWindowChange", "(IIILjava/lang/String;)V", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jint width, jint height, jint framerate, jstring jname) {
+                if (conn_fd != -1) {
+                    const char *name = (!jname || width <= 0 || height <= 0) ? NULL : env->GetStringUTFChars(jname, JNI_FALSE);
+                    sendEvent(.screenSize = { .t = EVENT_SCREEN_SIZE, .width = (uint16_t) width, .height = (uint16_t) height, .framerate = (uint16_t) framerate, .name_size = (name ? strlen(name) : 0) });
+                    if (name) {
+                        write(conn_fd, name, strlen(name));
+                        env->ReleaseStringUTFChars(jname, name);
+                    }
+                }
+            }},
+            {"sendMouseEvent", "(FFIZZ)V", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jfloat x, jfloat y, jint which_button, jboolean button_down, jboolean relative) {
+                if (conn_fd != -1) {
+                    if (which_button > 0)
+                        env->CallVoidMethod(globalThiz, MainActivity.resetIme);
+                    sendEvent(.mouse = { .t = EVENT_MOUSE, .x = x, .y = y, .detail = (uint8_t) which_button, .down = button_down, .relative = relative });
+                }
+            }},
+            {"sendTouchEvent", "(IIII)V", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jint action, jint id, jint x, jint y) {
+                if (action != -1)
+                    sendEvent(.touch = { .t = EVENT_TOUCH, .type = (uint16_t) action, .id = (uint16_t) id, .x = (uint16_t) x, .y = (uint16_t) y });
+            }},
+            {"sendStylusEvent", "(FFIIIIIZZ)V", (void *) +[](__unused JNIEnv *env, __unused jobject thiz, jfloat x, jfloat y, jint pressure, jint tilt_x, jint tilt_y, jint orientation, jint buttons, jboolean eraser, jboolean mouse) {
+                if (conn_fd != -1) {
+                    env->CallVoidMethod(globalThiz, MainActivity.resetIme);
+                    sendEvent(.stylus = { .t = EVENT_STYLUS, .x = x, .y = y, .pressure = (uint16_t) pressure, .tilt_x = (int8_t) tilt_x, .tilt_y = (int8_t) tilt_y, .orientation = (int16_t) orientation, .buttons = (uint8_t) buttons, .eraser = eraser, .mouse = mouse });
+                }
+            }},
+            {"requestStylusEnabled", "(Z)V", (void *) +[](__unused JNIEnv *env, __unused jclass clazz, jboolean enabled) {
+                sendEvent(.stylusEnable = { .t = EVENT_STYLUS_ENABLE, .enable = enabled });
+            }},
+            {"sendKeyEvent", "(IIZI)Z", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jint scan_code, jint key_code, jboolean key_down) -> jboolean {
+                if (conn_fd != -1) {
+                    int code = (scan_code) ?: android_to_linux_keycode[key_code];
+                    log(DEBUG, "Sending key: %d (%d %d %d)", code + 8, scan_code, key_code, key_down);
+                    sendEvent(.key = { .t = EVENT_KEY, .key = (uint16_t) (code + 8), .state = key_down });
+                }
+                return true;
+            }},
             {"sendTextEvent", "([B)V", (void *)&sendTextEvent},
             {"requestConnection", "()Z", (void *)&requestConnection},
     };

--- a/lorie/src/main/cpp/lorie/activity.cpp
+++ b/lorie/src/main/cpp/lorie/activity.cpp
@@ -45,26 +45,25 @@ static JNIEnv *guienv = NULL; // Must be used only in GUI thread.
 static jobject globalThiz = NULL;
 
 static jclass FindClassOrDie(JNIEnv *env, const char* name) {
-    jclass clazz = (*env)->FindClass(env, name);
+    jclass clazz = env->FindClass(name);
     if (!clazz) {
         char buffer[1024] = {0};
         sprintf(buffer, "class %s not found", name);
         log(ERROR, "%s", buffer);
-        (*env)->FatalError(env, buffer);
+        env->FatalError(buffer);
         return NULL;
     }
 
-    return (*env)->NewGlobalRef(env, clazz);
+    return (jclass) env->NewGlobalRef(clazz);
 }
 
-static jclass FindMethodOrDie(JNIEnv *env, jclass clazz, const char* name, const char* signature, jboolean isStatic) {
-    __typeof__((*env)->GetMethodID) getMethodID = isStatic ? (*env)->GetStaticMethodID : (*env)->GetMethodID;
-    jmethodID method = getMethodID(env, clazz, name, signature);
+static jmethodID FindMethodOrDie(JNIEnv *env, jclass clazz, const char* name, const char* signature, jboolean isStatic) {
+    jmethodID method = isStatic ? env->GetStaticMethodID(clazz, name, signature) : env->GetMethodID(clazz, name, signature);
     if (!method) {
         char buffer[1024] = {0};
         sprintf(buffer, "method %s %s not found", name, signature);
         log(ERROR, "%s", buffer);
-        (*env)->FatalError(env, buffer);
+        env->FatalError(buffer);
         return NULL;
     }
 
@@ -75,11 +74,13 @@ static jboolean requestConnection(__unused JNIEnv *env, __unused jclass clazz) {
 #define check(cond, fmt, ...) if ((cond)) do { __android_log_print(ANDROID_LOG_ERROR, "requestConnection", fmt, ## __VA_ARGS__); goto end; } while (0)
     bool sent = JNI_FALSE;
     // We do not want to block GUI thread for a long time so we will set timeout to 20 msec.
-    struct sockaddr_in server = { .sin_family = AF_INET, .sin_port = htons(PORT), .sin_addr.s_addr = inet_addr("127.0.0.1") };
+    struct sockaddr_in server = { .sin_family = AF_INET, .sin_port = htons(PORT) };
+    server.sin_addr.s_addr = inet_addr("127.0.0.1");
     int so_error, sock = socket(AF_INET, SOCK_STREAM, 0);
     check(sock < 0, "Could not create socket: %s", strerror(errno));
     check(fcntl(sock, F_SETFL, O_NONBLOCK) < 0, "failed to set socket non-block: %s", strerror(errno));
-    int r = connect(sock, (struct sockaddr *)&server, sizeof(server));
+    int r;
+    r = connect(sock, (struct sockaddr *)&server, sizeof(server));
     check(r < 0 && errno != EINPROGRESS, "failed to connect socket: %s", strerror(errno));
     if (r < 0 && errno == EINPROGRESS) {
         // Connection is in progress; use poll to wait for it
@@ -120,14 +121,14 @@ static void nativeInit(JNIEnv *env, jobject thiz) {
         MainActivity.self = FindClassOrDie(env,  "com/termux/x11/MainActivity");
         MainActivity.getInstance = FindMethodOrDie(env, MainActivity.self, "getInstance", "()Lcom/termux/x11/MainActivity;", JNI_TRUE);
         MainActivity.clientConnectedStateChanged = FindMethodOrDie(env, MainActivity.self, "clientConnectedStateChanged", "()V", JNI_FALSE);
-        MainActivity.resetIme = FindMethodOrDie(env, (*env)->GetObjectClass(env, thiz), "resetIme", "()V", JNI_FALSE);
+        MainActivity.resetIme = FindMethodOrDie(env, env->GetObjectClass(thiz), "resetIme", "()V", JNI_FALSE);
     }
 
     rendererInit(env);
 
-    (*env)->GetJavaVM(env, &vm);
-    (*vm)->AttachCurrentThread(vm, &guienv, NULL);
-    globalThiz = (*guienv)->NewGlobalRef(env, thiz);
+    env->GetJavaVM(&vm);
+    vm->AttachCurrentThread(&guienv, NULL);
+    globalThiz = guienv->NewGlobalRef(thiz);
     connect_(NULL, NULL, -1);
 }
 
@@ -136,9 +137,9 @@ static int xcallback(int fd, int events, __unused void* data) {
     jobject thiz = globalThiz;
 
     if (events & (ALOOPER_EVENT_ERROR | ALOOPER_EVENT_HANGUP)) {
-        jobject instance = (*env)->CallStaticObjectMethod(env, MainActivity.self, MainActivity.getInstance);
+        jobject instance = env->CallStaticObjectMethod(MainActivity.self, MainActivity.getInstance);
         if (instance)
-            (*env)->CallVoidMethod(env, instance, MainActivity.clientConnectedStateChanged);
+            env->CallVoidMethod(instance, MainActivity.clientConnectedStateChanged);
 
         ALooper_removeFd(ALooper_forThread(), fd);
         close(conn_fd);
@@ -163,18 +164,18 @@ static int xcallback(int fd, int events, __unused void* data) {
                     read(conn_fd, clipboard, sizeof(clipboard));
                     clipboard[e.clipboardSend.count] = 0;
                     log(DEBUG, "Clipboard content (%zu symbols) is %s", strlen(clipboard), clipboard);
-                    jmethodID id = (*env)->GetMethodID(env, (*env)->GetObjectClass(env, thiz), "setClipboardText","(Ljava/lang/String;)V");
-                    jobject bb = (*env)->NewDirectByteBuffer(env, clipboard, strlen(clipboard));
-                    jobject charset = (*env)->CallStaticObjectMethod(env, Charset.self, Charset.forName, (*env)->NewStringUTF(env, "UTF-8"));
-                    jobject cb = (*env)->CallObjectMethod(env, charset, Charset.decode, bb);
-                    (*env)->DeleteLocalRef(env, bb);
+                    jmethodID id = env->GetMethodID(env->GetObjectClass(thiz), "setClipboardText","(Ljava/lang/String;)V");
+                    jobject bb = env->NewDirectByteBuffer(clipboard, strlen(clipboard));
+                    jobject charset = env->CallStaticObjectMethod(Charset.self, Charset.forName, env->NewStringUTF("UTF-8"));
+                    jobject cb = env->CallObjectMethod(charset, Charset.decode, bb);
+                    env->DeleteLocalRef(bb);
 
-                    jstring str = (*env)->CallObjectMethod(env, cb, CharBuffer.toString);
-                    (*env)->CallVoidMethod(env, thiz, id, str);
+                    jstring str = (jstring) env->CallObjectMethod(cb, CharBuffer.toString);
+                    env->CallVoidMethod(thiz, id, str);
                     break;
                 }
                 case EVENT_CLIPBOARD_REQUEST: {
-                    (*env)->CallVoidMethod(env, thiz, (*env)->GetMethodID(env, (*env)->GetObjectClass(env, thiz), "requestClipboard", "()V"));
+                    env->CallVoidMethod(thiz, env->GetMethodID(env->GetObjectClass(thiz), "requestClipboard", "()V"));
                     break;
                 }
                 case EVENT_SHARED_SERVER_STATE: {
@@ -184,7 +185,7 @@ static int xcallback(int fd, int events, __unused void* data) {
                     if (stateFd < 0)
                         break;
 
-                    state = mmap(NULL, sizeof(*state), PROT_READ|PROT_WRITE, MAP_SHARED, stateFd, 0);
+                    state = (struct lorie_shared_server_state*) mmap(NULL, sizeof(*state), PROT_READ|PROT_WRITE, MAP_SHARED, stateFd, 0);
                     if (!state || state == MAP_FAILED) {
                         log(ERROR, "Failed to map server state: %s", strerror(errno));
                         state = NULL;
@@ -209,7 +210,7 @@ static int xcallback(int fd, int events, __unused void* data) {
                     break;
                 }
                 case EVENT_WINDOW_FOCUS_CHANGED: {
-                    (*env)->CallVoidMethod(env, thiz, MainActivity.resetIme);
+                    env->CallVoidMethod(thiz, MainActivity.resetIme);
                 }
             }
         }
@@ -263,7 +264,7 @@ static void startLogcat(JNIEnv *env, __unused jobject cls, jint fd) {
             sprintf(buf, "--pid=%d", getppid());
             execl("/system/bin/logcat", "logcat", buf, NULL);
             log(ERROR, "exec logcat: %s", strerror(errno));
-            (*env)->FatalError(env, "Exiting");
+            env->FatalError("Exiting");
     }
 }
 
@@ -283,23 +284,23 @@ static void sendClipboardAnnounce(__unused JNIEnv *env, __unused jobject thiz) {
 
 static void sendClipboardEvent(JNIEnv *env, __unused jobject thiz, jbyteArray text) {
     if (conn_fd != -1 && text) {
-        jsize length = (*env)->GetArrayLength(env, text);
-        jbyte* str = (*env)->GetByteArrayElements(env, text, NULL);
-        lorieEvent e = { .clipboardSend = { .t = EVENT_CLIPBOARD_SEND, .count = length } };
+        jsize length = env->GetArrayLength(text);
+        jbyte* str = env->GetByteArrayElements(text, NULL);
+        lorieEvent e = { .clipboardSend = { .t = EVENT_CLIPBOARD_SEND, .count = (uint32_t) length } };
         write(conn_fd, &e, sizeof(e));
         write(conn_fd, str, length);
-        (*env)->ReleaseByteArrayElements(env, text, str, JNI_ABORT);
+        env->ReleaseByteArrayElements(text, str, JNI_ABORT);
     }
 }
 
 static void sendWindowChange(__unused JNIEnv* env, __unused jobject cls, jint width, jint height, jint framerate, jstring jname) {
     if (conn_fd != -1) {
-        const char *name = (!jname || width <= 0 || height <= 0) ? NULL : (*env)->GetStringUTFChars(env, jname, JNI_FALSE);
-        lorieEvent e = { .screenSize = { .t = EVENT_SCREEN_SIZE, .width = width, .height = height, .framerate = framerate, .name_size = (name ? strlen(name) : 0) } };
+        const char *name = (!jname || width <= 0 || height <= 0) ? NULL : env->GetStringUTFChars(jname, JNI_FALSE);
+        lorieEvent e = { .screenSize = { .t = EVENT_SCREEN_SIZE, .width = (uint16_t) width, .height = (uint16_t) height, .framerate = (uint16_t) framerate, .name_size = (name ? strlen(name) : 0) } };
         write(conn_fd, &e, sizeof(e));
         if (name) {
             write(conn_fd, name, strlen(name));
-            (*env)->ReleaseStringUTFChars(env, jname, name);
+            env->ReleaseStringUTFChars(jname, name);
         }
     }
 }
@@ -307,15 +308,15 @@ static void sendWindowChange(__unused JNIEnv* env, __unused jobject cls, jint wi
 static void sendMouseEvent(__unused JNIEnv* env, __unused jobject cls, jfloat x, jfloat y, jint which_button, jboolean button_down, jboolean relative) {
     if (conn_fd != -1) {
         if (which_button > 0)
-            (*env)->CallVoidMethod(env, globalThiz, MainActivity.resetIme);
-        lorieEvent e = { .mouse = { .t = EVENT_MOUSE, .x = x, .y = y, .detail = which_button, .down = button_down, .relative = relative } };
+            env->CallVoidMethod(globalThiz, MainActivity.resetIme);
+        lorieEvent e = { .mouse = { .t = EVENT_MOUSE, .x = x, .y = y, .detail = (uint8_t) which_button, .down = button_down, .relative = relative } };
         write(conn_fd, &e, sizeof(e));
     }
 }
 
 static void sendTouchEvent(__unused JNIEnv* env, __unused jobject cls, jint action, jint id, jint x, jint y) {
     if (conn_fd != -1 && action != -1) {
-        lorieEvent e = { .touch = { .t = EVENT_TOUCH, .type = action, .id = id, .x = x, .y = y } };
+        lorieEvent e = { .touch = { .t = EVENT_TOUCH, .type = (uint16_t) action, .id = (uint16_t) id, .x = (uint16_t) x, .y = (uint16_t) y } };
         write(conn_fd, &e, sizeof(e));
     }
 }
@@ -324,8 +325,8 @@ static void sendStylusEvent(__unused JNIEnv *env, __unused jobject thiz, jfloat 
                             jint pressure, jint tilt_x, jint tilt_y,
                             jint orientation, jint buttons, jboolean eraser, jboolean mouse) {
     if (conn_fd != -1) {
-        (*env)->CallVoidMethod(env, globalThiz, MainActivity.resetIme);
-        lorieEvent e = { .stylus = { .t = EVENT_STYLUS, .x = x, .y = y, .pressure = pressure, .tilt_x = tilt_x, .tilt_y = tilt_y, .orientation = orientation, .buttons = buttons, .eraser = eraser, .mouse = mouse } };
+        env->CallVoidMethod(globalThiz, MainActivity.resetIme);
+        lorieEvent e = { .stylus = { .t = EVENT_STYLUS, .x = x, .y = y, .pressure = (uint16_t) pressure, .tilt_x = (int8_t) tilt_x, .tilt_y = (int8_t) tilt_y, .orientation = (int16_t) orientation, .buttons = (uint8_t) buttons, .eraser = eraser, .mouse = mouse } };
         write(conn_fd, &e, sizeof(e));
     }
 }
@@ -341,7 +342,7 @@ static jboolean sendKeyEvent(__unused JNIEnv* env, __unused jobject cls, jint sc
     if (conn_fd != -1) {
         int code = (scan_code) ?: android_to_linux_keycode[key_code];
         log(DEBUG, "Sending key: %d (%d %d %d)", code + 8, scan_code, key_code, key_down);
-        lorieEvent e = { .key = { .t = EVENT_KEY, .key = code + 8, .state = key_down } };
+        lorieEvent e = { .key = { .t = EVENT_KEY, .key = (uint16_t) (code + 8), .state = key_down } };
         write(conn_fd, &e, sizeof(e));
     }
 
@@ -350,8 +351,8 @@ static jboolean sendKeyEvent(__unused JNIEnv* env, __unused jobject cls, jint sc
 
 static void sendTextEvent(JNIEnv *env, __unused jobject thiz, jbyteArray text) {
     if (conn_fd != -1 && text) {
-        jsize length = (*env)->GetArrayLength(env, text);
-        jbyte *str = (*env)->GetByteArrayElements(env, text, NULL);
+        jsize length = env->GetArrayLength(text);
+        jbyte *str = env->GetByteArrayElements(text, NULL);
         char *p = (char*) str;
         mbstate_t mbstate = { 0 };
         if (!length)
@@ -372,7 +373,7 @@ static void sendTextEvent(JNIEnv *env, __unused jobject thiz, jbyteArray text) {
                 break;
 
             log(DEBUG, "Sending unicode event: %lc (U+%X)", wc, wc);
-            lorieEvent e = { .unicode = { .t = EVENT_UNICODE, .code = wc } };
+            lorieEvent e = { .unicode = { .t = EVENT_UNICODE, .code = (uint32_t) wc } };
             write(conn_fd, &e, sizeof(e));
             p += len;
             if (p - (char*) str >= length)
@@ -380,7 +381,7 @@ static void sendTextEvent(JNIEnv *env, __unused jobject thiz, jbyteArray text) {
             usleep(2500);
         }
 
-        (*env)->ReleaseByteArrayElements(env, text, str, JNI_ABORT);
+        env->ReleaseByteArrayElements(text, str, JNI_ABORT);
     }
 }
 
@@ -407,9 +408,9 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *vm, __unused void *reserved) {
             {"sendTextEvent", "([B)V", (void *)&sendTextEvent},
             {"requestConnection", "()Z", (void *)&requestConnection},
     };
-    (*vm)->AttachCurrentThread(vm, &env, NULL);
-    jclass cls = (*env)->FindClass(env, "com/termux/x11/LorieView");
-    (*env)->RegisterNatives(env, cls, methods, sizeof(methods)/sizeof(methods[0]));
+    vm->AttachCurrentThread(&env, NULL);
+    jclass cls = env->FindClass("com/termux/x11/LorieView");
+    env->RegisterNatives(cls, methods, sizeof(methods)/sizeof(methods[0]));
 
     return JNI_VERSION_1_6;
 }

--- a/lorie/src/main/cpp/lorie/lorie.h
+++ b/lorie/src/main/cpp/lorie/lorie.h
@@ -40,20 +40,10 @@ void lorieSendSharedServerState(int memfd);
 void lorieRegisterBuffer(LorieBuffer* buffer);
 void lorieUnregisterBuffer(LorieBuffer* buffer);
 bool lorieConnectionAlive(void);
-extern bool lorieDebugEnabled; // Set in activity.c's startLogcat, only called when TERMUX_X11_DEBUG=1.
+extern bool lorieDebugEnabled; // Set in activity.cpp's startLogcat, only called when TERMUX_X11_DEBUG=1.
 void lorieSetRendererWakeupCond(int fd);
-int rendererGetWakeupCondFd(void);
 
-__unused void rendererInit(JNIEnv* env);
-__unused void rendererSetFiltering(JNIEnv* env, jobject self, jint filtering);
 __unused void rendererTestCapabilities(int* legacy_drawing);
-__unused void rendererSetWindow(JNIEnv *env, jobject thiz, jobject sfc);
-__unused void rendererSetViewport(JNIEnv *env, jclass clazz, int x, int y, int w, int h, int ew, int eh);
-__unused void rendererSetZoom(JNIEnv *env, jclass clazz, int percent);
-__unused void rendererSetSharedState(struct lorie_shared_server_state* newState);
-__unused void rendererAddBuffer(LorieBuffer* buf);
-__unused void rendererRemoveBuffer(uint64_t id);
-__unused void rendererRemoveAllBuffers(void);
 
 static inline __always_inline void lorie_mutex_lock(pthread_mutex_t* mutex, pid_t* lockingPid) {
     // Unfortunately there is no robust mutexes in bionic.
@@ -270,6 +260,7 @@ struct Renderer {
     volatile int zoomPercent = 100;
     float zoomSourceLeft = 0.f, zoomSourceTop = 0.f;
     JNIEnv* rendererEnv = nullptr;
+    JavaVM* jvm = nullptr; // Stashed by init() so initThread() can be reached via `this` from a plain (non-capturing) pthread_create callback.
     jclass lorieViewClass = nullptr;
     jmethodID setRendererViewportMethod = nullptr;
     int reportedViewportX = -1, reportedViewportY = -1, reportedViewportW = -1, reportedViewportH = -1;
@@ -310,7 +301,7 @@ struct Renderer {
     uint64_t lastRequestedBufferId = 0;
 
     void init(JNIEnv* env);
-    void* initThread(JavaVM* vm);
+    void* initThread();
     int getWakeupCondFd();
     void setFiltering(jint f);
     void testCapabilities(int* legacy_drawing);

--- a/lorie/src/main/cpp/lorie/renderer.cpp
+++ b/lorie/src/main/cpp/lorie/renderer.cpp
@@ -125,10 +125,6 @@ static void notifyGpuCopyDone(void) {
     }
 }
 
-// Renderer itself is declared in lorie.h so activity.cpp will be able to hold an instance
-// directly once it's converted too. For now there is still exactly one instance (g_renderer).
-static Renderer g_renderer;
-
 void Renderer::bindTexture(GLuint id) {
     glBindTexture(GL_TEXTURE_2D, id);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filtering);
@@ -168,8 +164,8 @@ static const EGLint ctxattribs[] = {
         EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE
 };
 
-void* Renderer::initThread(JavaVM* vm) {
-    if (vm->AttachCurrentThread(&rendererEnv, NULL) != JNI_OK) {
+void* Renderer::initThread() {
+    if (jvm->AttachCurrentThread(&rendererEnv, NULL) != JNI_OK) {
         log("Failed to attach renderer thread to JVM");
         return nullptr;
     }
@@ -260,12 +256,11 @@ void* Renderer::initThread(JavaVM* vm) {
 
 void Renderer::init(JNIEnv* env) {
     pthread_t t;
-    JavaVM* vm;
 
     if (ctx)
         return;
 
-    env->GetJavaVM(&vm);
+    env->GetJavaVM(&jvm);
     jclass clazz = env->FindClass("com/termux/x11/LorieView");
     lorieViewClass = (jclass) env->NewGlobalRef(clazz);
     setRendererViewportMethod = env->GetStaticMethodID(lorieViewClass, "setRendererViewport", "(IIIIFFFF)V");
@@ -288,8 +283,8 @@ void Renderer::init(JNIEnv* env) {
     pthread_spin_init(&bufferLock, false);
 
     pthread_create(&t, NULL, +[](void* cookie) -> void* {
-        return g_renderer.initThread((JavaVM*) cookie);
-    }, vm);
+        return ((Renderer*) cookie)->initThread();
+    }, this);
 }
 
 int Renderer::getWakeupCondFd() {
@@ -407,6 +402,11 @@ void Renderer::testCapabilities(int* legacy_drawing) {
         eglDestroySurface(egl_display, checksfc);
         AHardwareBuffer_release(new_);
     }
+}
+
+void rendererTestCapabilities(int* legacy_drawing) {
+    Renderer scratch;
+    scratch.testCapabilities(legacy_drawing);
 }
 
 void Renderer::setSharedState(struct lorie_shared_server_state* newState) {
@@ -1076,16 +1076,3 @@ void Renderer::drawCursor(float displayWidth, float displayHeight, float sourceL
     drawRegion(cursor.id, x, y, x + w, y + h, 0.f, 0.f, 1.f, 1.f, false);
     glDisable(GL_BLEND);
 }
-
-// JNI-facing entry points; these are the only places g_renderer is referenced by name.
-void rendererInit(JNIEnv* env) { g_renderer.init(env); }
-int rendererGetWakeupCondFd(void) { return g_renderer.getWakeupCondFd(); }
-void rendererSetFiltering(JNIEnv* env, jobject self, jint filtering) { g_renderer.setFiltering(filtering); }
-void rendererTestCapabilities(int* legacy_drawing) { g_renderer.testCapabilities(legacy_drawing); }
-void rendererSetSharedState(struct lorie_shared_server_state* newState) { g_renderer.setSharedState(newState); }
-void rendererAddBuffer(LorieBuffer* buf) { g_renderer.addBuffer(buf); }
-void rendererRemoveBuffer(uint64_t id) { g_renderer.removeBuffer(id); }
-void rendererRemoveAllBuffers(void) { g_renderer.removeAllBuffers(); }
-void rendererSetWindow(JNIEnv *env, jobject thiz, jobject sfc) { g_renderer.setWindow(env, sfc); }
-void rendererSetViewport(JNIEnv *env, jclass clazz, int x, int y, int w, int h, int ew, int eh) { g_renderer.setViewport(x, y, w, h, ew, eh); }
-void rendererSetZoom(JNIEnv *env, jclass clazz, int percent) { g_renderer.setZoom(percent); }

--- a/lorie/src/main/cpp/recipes/xserver.cmake
+++ b/lorie/src/main/cpp/recipes/xserver.cmake
@@ -288,10 +288,10 @@ add_library(Xlorie SHARED
         "lorie/InputXKB.c"
         "lorie/renderer.cpp"
         "lorie/buffer.c"
-        "lorie/activity.c")
+        "lorie/activity.cpp")
 target_include_directories(Xlorie PRIVATE ${inc} "libxcvt/include")
-# -nostdlib++ keeps this shared object free of any libc++ dependency; renderer.cpp is restricted
-# to a runtime-free subset of C++ (no exceptions, no RTTI, no STL) to make that possible.
+# -nostdlib++ keeps this shared object free of any libc++ dependency; renderer.cpp and activity.cpp
+# are restricted to a runtime-free subset of C++ (no exceptions, no RTTI, no STL) to make that possible.
 target_link_options(Xlorie PRIVATE "-Wl,--as-needed" "-Wl,--no-undefined" "-fvisibility=hidden" "-nostdlib++")
 target_link_libraries(Xlorie "-Wl,--whole-archive" ${XSERVER_LIBS} "-Wl,--no-whole-archive" android mediandk log m z EGL GLESv2)
 target_compile_options(Xlorie PRIVATE ${compile_options} "$<$<COMPILE_LANGUAGE:C>:${c_only_compile_options}>" "$<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions;-fno-rtti>")


### PR DESCRIPTION
Same treatment as `renderer.cpp`: `activity.c` becomes `activity.cpp`, JNI calls converted to method-call syntax, no libc++ dependency. Small one-off JNI methods are now inline lambdas in the `JNINativeMethod` table (via a `sendEvent()` macro); `g_renderer` moved from `renderer.cpp` into `activity.cpp` since that's now its only user.