### PR TITLE
feat(lorie): keep the display size and proportions in picture-in-picture

### DIFF
--- a/lorie/src/main/java/com/termux/x11/LorieView.java
+++ b/lorie/src/main/java/com/termux/x11/LorieView.java
@@ -25,6 +25,7 @@ import android.text.InputType;
 import android.text.Selection;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.util.Rational;
 import android.view.KeyEvent;
 import android.view.Display;
 import android.view.Surface;
@@ -70,6 +71,7 @@ import dalvik.annotation.optimization.FastNative;
 @SuppressWarnings("deprecation")
 public class LorieView extends SurfaceView implements InputStub {
     private static int rendererZoom = 100;
+    private static final Rect NO_INSETS = new Rect();
 
     public interface Callback {
         void inputTransformChanged(int screenWidth, int screenHeight, Matrix inputTransform);
@@ -92,6 +94,7 @@ public class LorieView extends SurfaceView implements InputStub {
     private final Matrix inputTransform = new Matrix();
     private float inputSourceLeft = 0.f, inputSourceTop = 0.f;
     private float inputSourceWidth = 0.f, inputSourceHeight = 0.f;
+    private boolean dimensionsFrozen = false;
     boolean commitedText = false;
     private final InputConnection mConnection = new BaseInputConnection(this, false) {
         private final MainActivity a = MainActivity.getInstance();
@@ -433,6 +436,21 @@ public class LorieView extends SurfaceView implements InputStub {
         });
     }
 
+    /** Keeps the X screen size while the window is being resized, the picture is scaled instead. */
+    public void freezeDimensions(boolean freeze) {
+        if (dimensionsFrozen == freeze || (freeze && (p.x == 0 || p.y == 0)))
+            return;
+
+        dimensionsFrozen = freeze;
+        if (!freeze)
+            requestLayout(); // measuring is what reapplies the dimensions, and the window may still be resizing
+    }
+
+    /** Aspect ratio of the area the X screen is drawn in, null if the view is not laid out yet. */
+    public Rational getViewportAspectRatio() {
+        return viewport.isEmpty() ? null : new Rational(viewport.width(), viewport.height());
+    }
+
     public void setContentInsets(int left, int top, int right, int bottom) {
         if (contentInsets.left == left && contentInsets.top == top && contentInsets.right == right && contentInsets.bottom == bottom)
             return;
@@ -445,14 +463,17 @@ public class LorieView extends SurfaceView implements InputStub {
         Prefs prefs = MainActivity.getPrefs();
 
         int surfaceW = getMeasuredWidth(), surfaceH = getMeasuredHeight();
-        int availableLeft = contentInsets.left, availableTop = contentInsets.top;
-        int availableW = Math.max(0, surfaceW - contentInsets.left - contentInsets.right);
-        int availableH = Math.max(0, surfaceH - contentInsets.top - contentInsets.bottom);
+        // Views the insets reserve room for are hidden while the dimensions are frozen.
+        Rect insets = dimensionsFrozen ? NO_INSETS : contentInsets;
+        int availableLeft = insets.left, availableTop = insets.top;
+        int availableW = Math.max(0, surfaceW - insets.left - insets.right);
+        int availableH = Math.max(0, surfaceH - insets.top - insets.bottom);
 
         if (availableW == 0 || availableH == 0)
             return;
 
-        getDimensionsFromSettings(availableW, availableH);
+        if (!dimensionsFrozen)
+            getDimensionsFromSettings(availableW, availableH);
 
         int drawW = availableW;
         int drawH = availableH;
@@ -477,7 +498,8 @@ public class LorieView extends SurfaceView implements InputStub {
         setViewport(viewport.left, viewport.top, viewport.width(), viewport.height(), p.x, p.y);
 
         updateInputTransform();
-        sendWindowChange();
+        if (!dimensionsFrozen)
+            sendWindowChange();
     }
 
     @Override

--- a/lorie/src/main/java/com/termux/x11/MainActivity.java
+++ b/lorie/src/main/java/com/termux/x11/MainActivity.java
@@ -14,6 +14,7 @@ import android.app.AppOpsManager;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.PictureInPictureParams;
 import android.content.BroadcastReceiver;
 import android.content.ClipData;
 import android.content.Context;
@@ -22,6 +23,7 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.net.Uri;
@@ -36,6 +38,8 @@ import android.os.SystemClock;
 import android.service.notification.StatusBarNotification;
 import android.util.DisplayMetrics;
 import android.util.Log;
+import android.util.Rational;
+import android.util.TypedValue;
 import android.view.DragEvent;
 import android.view.InputDevice;
 import android.view.KeyEvent;
@@ -91,6 +95,9 @@ public class MainActivity extends AppCompatActivity {
     private boolean filterOutWinKey = false;
     boolean useTermuxEKBarBehaviour = false;
     private boolean isInPictureInPictureMode = false;
+    /** Aspect ratios outside of the range the device is configured with are rejected by the system. */
+    private static final float MIN_PIP_ASPECT_RATIO = getSystemDimenFloat("config_pictureInPictureMinAspectRatio", 1.f / 2.39f);
+    private static final float MAX_PIP_ASPECT_RATIO = getSystemDimenFloat("config_pictureInPictureMaxAspectRatio", 2.39f);
 
     public static Prefs prefs = null;
 
@@ -808,6 +815,15 @@ public class MainActivity extends AppCompatActivity {
     public void onBackPressed() {
     }
 
+    private static float getSystemDimenFloat(String name, float fallback) {
+        Resources resources = Resources.getSystem();
+        TypedValue value = new TypedValue();
+        int id = resources.getIdentifier(name, "dimen", "android");
+        if (id != 0)
+            resources.getValue(id, value, true);
+        return value.type == TypedValue.TYPE_FLOAT ? value.getFloat() : fallback;
+    }
+
     public static boolean hasPipPermission(@NonNull Context context) {
         AppOpsManager appOpsManager = (AppOpsManager) context.getSystemService(Context.APP_OPS_SERVICE);
         if (appOpsManager == null)
@@ -820,14 +836,28 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     public void onUserLeaveHint() {
-        if (prefs.PIP.get() && hasPipPermission(this)) {
-            enterPictureInPictureMode();
+        if (!prefs.PIP.get() || !hasPipPermission(this))
+            return;
+
+        PictureInPictureParams.Builder params = new PictureInPictureParams.Builder();
+        Rational aspectRatio = getLorieView().getViewportAspectRatio();
+        if (aspectRatio != null) {
+            float clamped = MathUtils.clamp(aspectRatio.floatValue(), MIN_PIP_ASPECT_RATIO, MAX_PIP_ASPECT_RATIO);
+            if (clamped != aspectRatio.floatValue())
+                // Truncating instead of rounding keeps the ratio from landing back outside of the range.
+                aspectRatio = clamped > 1 ? new Rational((int) (clamped * 1000), 1000) : new Rational(1000, (int) (1000 / clamped));
+            params.setAspectRatio(aspectRatio);
         }
+
+        getLorieView().freezeDimensions(true);
+        if (!enterPictureInPictureMode(params.build()))
+            getLorieView().freezeDimensions(false);
     }
 
     @Override
     public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode, @NonNull Configuration newConfig) {
         this.isInPictureInPictureMode = isInPictureInPictureMode;
+        getLorieView().freezeDimensions(isInPictureInPictureMode);
         final ViewPager pager = getTerminalToolbarViewPager();
         pager.setAlpha(isInPictureInPictureMode ? 0.f : ((float) prefs.opacityEKBar.get())/100);
         findViewById(R.id.mouse_buttons).setAlpha(isInPictureInPictureMode ? 0.f : 0.7f);


### PR DESCRIPTION
The window is entered with the aspect ratio of the viewport it had before, clamped to the range the device accepts, and the X screen size along with the insets of the overlays hidden there is kept until the window is back to its normal size, so the picture is only scaled while it floats.