### PR TITLE
feat(lorie): scroll the picture to the cursor under the soft keyboard

### DIFF
--- a/lorie/src/main/cpp/lorie/activity.cpp
+++ b/lorie/src/main/cpp/lorie/activity.cpp
@@ -309,8 +309,8 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *vm, __unused void *reserved) {
             {"surfaceChanged", "(Landroid/view/Surface;)V", (void *) +[](JNIEnv *env, __unused jobject thiz, jobject sfc) {
                 g_renderer.setWindow(env, sfc);
             }},
-            {"setViewport", "(IIIIII)V", (void *) +[](__unused JNIEnv *env, __unused jclass clazz, jint x, jint y, jint w, jint h, jint ew, jint eh) {
-                g_renderer.setViewport(x, y, w, h, ew, eh);
+            {"setViewport", "(IIIIIII)V", (void *) +[](__unused JNIEnv *env, __unused jclass clazz, jint x, jint y, jint w, jint h, jint ew, jint eh, jint hidden) {
+                g_renderer.setViewport(x, y, w, h, ew, eh, hidden);
             }},
             {"setRendererZoom", "(I)V", (void *) +[](__unused JNIEnv *env, __unused jclass clazz, jint percent) {
                 g_renderer.setZoom(percent);

--- a/lorie/src/main/cpp/lorie/lorie.h
+++ b/lorie/src/main/cpp/lorie/lorie.h
@@ -257,8 +257,9 @@ struct Renderer {
     struct lorie_shared_server_state* pendingState = nullptr;
     ANativeWindow* pendingWin = nullptr;
     volatile int viewportX = 0, viewportY = 0, viewportW = 0, viewportH = 0, expectedW = 0, expectedH = 0;
+    volatile int hiddenBottom = 0;
     volatile int zoomPercent = 100;
-    float zoomSourceLeft = 0.f, zoomSourceTop = 0.f;
+    float panSourceLeft = 0.f, panSourceTop = 0.f;
     JNIEnv* rendererEnv = nullptr;
     JavaVM* jvm = nullptr; // Stashed by init() so initThread() can be reached via `this` from a plain (non-capturing) pthread_create callback.
     jclass lorieViewClass = nullptr;
@@ -310,7 +311,7 @@ struct Renderer {
     void removeBuffer(uint64_t id);
     void removeAllBuffers();
     void setWindow(JNIEnv* env, jobject jsfc);
-    void setViewport(int x, int y, int w, int h, int ew, int eh);
+    void setViewport(int x, int y, int w, int h, int ew, int eh, int hidden);
     void setZoom(int percent);
     void releaseWinAndSurface(ANativeWindow** anw, EGLSurface* esfc);
     void refreshContext();

--- a/lorie/src/main/cpp/lorie/renderer.cpp
+++ b/lorie/src/main/cpp/lorie/renderer.cpp
@@ -510,7 +510,7 @@ void Renderer::releaseWinAndSurface(ANativeWindow** anw, EGLSurface *esfc) {
     }
 }
 
-void Renderer::setViewport(int x, int y, int w, int h, int ew, int eh) {
+void Renderer::setViewport(int x, int y, int w, int h, int ew, int eh, int hidden) {
     pthread_mutex_lock(&stateLock);
     viewportX = x;
     viewportY = y;
@@ -518,6 +518,7 @@ void Renderer::setViewport(int x, int y, int w, int h, int ew, int eh) {
     viewportH = h;
     expectedW = ew;
     expectedH = eh;
+    hiddenBottom = hidden;
     viewportChanged = true;
     reportedViewportX = reportedViewportY = reportedViewportW = reportedViewportH = -1;
     reportedSourceLeft = reportedSourceTop = reportedSourceWidth = reportedSourceHeight = -1.f;
@@ -533,7 +534,7 @@ void Renderer::setZoom(int percent) {
     reportedViewportX = reportedViewportY = reportedViewportW = reportedViewportH = -1;
     reportedSourceLeft = reportedSourceTop = reportedSourceWidth = reportedSourceHeight = -1.f;
     if (zoomPercent == 100)
-        zoomSourceLeft = zoomSourceTop = 0.f;
+        panSourceLeft = panSourceTop = 0.f;
     if (state)
         state->drawRequested = true;
     pthread_cond_signal(stateCond);
@@ -735,6 +736,17 @@ void Renderer::applyPendingGpuCopies() {
     lorie_mutex_unlock(&state->lock, &state->lockingPid);
 }
 
+// Keeps the shown region still while the cursor stays inside it, panning only when the cursor
+// enters the 5% band near an edge.
+static float panToCursor(float offset, float cursor, float shown, float total) {
+    float edge = shown * 0.05f;
+    if (cursor < offset + edge)
+        offset = cursor - edge;
+    else if (cursor > offset + shown - edge)
+        offset = cursor - shown + edge;
+    return fmaxf(0.f, fminf(offset, total - shown));
+}
+
 void Renderer::redrawLocked(bool* waitingForBuffers) {
     float xfactor = 1.f;
     const LorieBuffer_Desc *desc = NULL;
@@ -792,12 +804,6 @@ void Renderer::redrawLocked(bool* waitingForBuffers) {
         renderViewportY = (int) (centerY - (float) renderViewportH / 2.f + 0.5f);
     }
 
-    glDisable(GL_SCISSOR_TEST);
-    glViewport(0, 0, surfaceW, surfaceH);
-    glClearColor(0.f, 0.f, 0.f, 1.f);
-    glClear(GL_COLOR_BUFFER_BIT);
-    glViewport(renderViewportX, surfaceH - renderViewportY - renderViewportH, renderViewportW, renderViewportH);
-    float sourceLeft = 0.f, sourceTop = 0.f;
     float sourceWidth = (float) desc->width, sourceHeight = (float) desc->height;
     float logicalSourceWidth = (float) expectedW, logicalSourceHeight = (float) expectedH;
     if (zoomPercent > 100) {
@@ -806,37 +812,31 @@ void Renderer::redrawLocked(bool* waitingForBuffers) {
         sourceHeight = (float) expectedH * destinationScaleY / requestedScale;
         logicalSourceWidth = sourceWidth;
         logicalSourceHeight = sourceHeight;
-        // Keep the zoomed region stable while the cursor stays inside the central 90%.
-        // Only pan when the cursor enters this 5% edge band near any side.
-        float edgeX = sourceWidth * 0.05f;
-        float edgeY = sourceHeight * 0.05f;
-        float cursorX = (float) state->cursor.x;
-        float cursorY = (float) state->cursor.y;
+    }
 
-        if (cursorX < zoomSourceLeft + edgeX)
-            zoomSourceLeft = cursorX - edgeX;
-        else if (cursorX > zoomSourceLeft + sourceWidth - edgeX)
-            zoomSourceLeft = cursorX - sourceWidth + edgeX;
+    // The soft keyboard hides the bottom of the picture instead of the picture shrinking for it,
+    // so only the part fitting above it is drawn, at the same scale as the whole picture.
+    int cut = renderViewportY + renderViewportH - (viewportY + viewportH - hiddenBottom);
+    if (hiddenBottom > 0 && cut > 0 && cut < renderViewportH) {
+        float shown = (float) (renderViewportH - cut) / (float) renderViewportH;
+        sourceHeight *= shown;
+        logicalSourceHeight *= shown;
+        renderViewportH -= cut;
+    }
 
-        if (cursorY < zoomSourceTop + edgeY)
-            zoomSourceTop = cursorY - edgeY;
-        else if (cursorY > zoomSourceTop + sourceHeight - edgeY)
-            zoomSourceTop = cursorY - sourceHeight + edgeY;
+    // The buffer can be a few pixels narrower than the screen because of the mode granularity,
+    // so panning horizontally only makes sense when zoomed in.
+    panSourceLeft = zoomPercent > 100
+                    ? panToCursor(panSourceLeft, (float) state->cursor.x, sourceWidth, (float) expectedW) : 0.f;
+    panSourceTop = sourceHeight < (float) expectedH
+                   ? panToCursor(panSourceTop, (float) state->cursor.y, sourceHeight, (float) expectedH) : 0.f;
+    float sourceLeft = panSourceLeft, sourceTop = panSourceTop;
 
-        if (zoomSourceLeft < 0.f)
-            zoomSourceLeft = 0.f;
-        else if (zoomSourceLeft + sourceWidth > (float) expectedW)
-            zoomSourceLeft = (float) expectedW - sourceWidth;
-
-        if (zoomSourceTop < 0.f)
-            zoomSourceTop = 0.f;
-        else if (zoomSourceTop + sourceHeight > (float) expectedH)
-            zoomSourceTop = (float) expectedH - sourceHeight;
-
-        sourceLeft = zoomSourceLeft;
-        sourceTop = zoomSourceTop;
-    } else
-        zoomSourceLeft = zoomSourceTop = 0.f;
+    glDisable(GL_SCISSOR_TEST);
+    glViewport(0, 0, surfaceW, surfaceH);
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glViewport(renderViewportX, surfaceH - renderViewportY - renderViewportH, renderViewportW, renderViewportH);
 
     reportViewport(renderViewportX, renderViewportY, renderViewportW, renderViewportH,
                    sourceLeft, sourceTop, logicalSourceWidth, logicalSourceHeight);

--- a/lorie/src/main/java/com/termux/x11/LorieView.java
+++ b/lorie/src/main/java/com/termux/x11/LorieView.java
@@ -91,6 +91,7 @@ public class LorieView extends SurfaceView implements InputStub {
     private final Rect contentInsets = new Rect();
     private final Rect viewport = new Rect();
     private final Rect inputViewport = new Rect();
+    private int obscuredBottom = 0;
     private final Matrix inputTransform = new Matrix();
     private float inputSourceLeft = 0.f, inputSourceTop = 0.f;
     private float inputSourceWidth = 0.f, inputSourceHeight = 0.f;
@@ -459,6 +460,15 @@ public class LorieView extends SurfaceView implements InputStub {
         return p.x == 0 || p.y == 0 ? null : new Rational(p.x, p.y);
     }
 
+    /** Height of the picture the soft keyboard covers instead of the picture being shrunk for it. */
+    public void setObscuredBottom(int height) {
+        if (obscuredBottom == height)
+            return;
+
+        obscuredBottom = height;
+        updateViewport();
+    }
+
     public void setContentInsets(int left, int top, int right, int bottom) {
         if (contentInsets.left == left && contentInsets.top == top && contentInsets.right == right && contentInsets.bottom == bottom)
             return;
@@ -494,17 +504,21 @@ public class LorieView extends SurfaceView implements InputStub {
                 drawH = drawW * p.y / p.x;
         }
 
+        // The picture keeps its size when the soft keyboard covers the bottom, it is just centered
+        // in what is left visible, and only what still does not fit there is left to be scrolled.
+        int visibleH = Math.max(0, availableH - obscuredBottom);
         int left = availableLeft + (availableW - drawW) / 2;
-        int top = availableTop + (availableH - drawH) / 2;
+        int top = availableTop + Math.max(0, (visibleH - drawH) / 2);
 
         viewport.set(left, top, left + drawW, top + drawH);
-        if (rendererZoom == 100 || inputSourceWidth == 0.f || inputSourceHeight == 0.f) {
+        int hiddenBottom = Math.max(0, viewport.bottom - (availableTop + visibleH));
+        if ((rendererZoom == 100 && hiddenBottom == 0) || inputSourceWidth == 0.f || inputSourceHeight == 0.f) {
             inputViewport.set(viewport);
             inputSourceLeft = inputSourceTop = 0.f;
             inputSourceWidth = p.x;
             inputSourceHeight = p.y;
         }
-        setViewport(viewport.left, viewport.top, viewport.width(), viewport.height(), p.x, p.y);
+        setViewport(viewport.left, viewport.top, viewport.width(), viewport.height(), p.x, p.y, hiddenBottom);
 
         updateInputTransform();
         if (!dimensionsFrozen)
@@ -677,7 +691,7 @@ public class LorieView extends SurfaceView implements InputStub {
     @FastNative public native void sendClipboardAnnounce();
     @FastNative public native void sendClipboardEvent(byte[] text);
     @FastNative static native void sendWindowChange(int width, int height, int framerate, String name);
-    @FastNative static native void setViewport(int x, int y, int width, int height, int expectedWidth, int expectedHeight);
+    @FastNative static native void setViewport(int x, int y, int width, int height, int expectedWidth, int expectedHeight, int hiddenBottom);
     @FastNative private static native void setRendererZoom(int percent);
 
     public void adjustRendererZoom(int delta) {

--- a/lorie/src/main/java/com/termux/x11/MainActivity.java
+++ b/lorie/src/main/java/com/termux/x11/MainActivity.java
@@ -691,6 +691,7 @@ public class MainActivity extends AppCompatActivity {
     private void applyContentInsets() {
         int imeContentInset = prefs.Reseed.get() ? imeHeight : 0;
         getLorieView().setContentInsets(0, captionHeight, 0, ekbarContentInset + imeContentInset);
+        getLorieView().setObscuredBottom(imeHeight - imeContentInset);
 
         ViewPager pager = getTerminalToolbarViewPager();
         ViewGroup.MarginLayoutParams pagerParams = (ViewGroup.MarginLayoutParams) pager.getLayoutParams();


### PR DESCRIPTION
Without reseeding the screen keeps its size, so the picture is centered in what the keyboard leaves visible and the part which still does not fit is scrolled to the cursor, reusing the panning of the zoom.