### PR TITLE
feat(lorie): add a preference to show the extra keys bar with the soft keyboard

### DIFF
--- a/lorie/src/main/java/com/termux/x11/LoriePreferences.java
+++ b/lorie/src/main/java/com/termux/x11/LoriePreferences.java
@@ -276,12 +276,17 @@ public class LoriePreferences extends AppCompatActivity implements PreferenceFra
             setSummary("adjustResolution", R.string.lorie_pref_summary_requiresExactOrCustom);
             setSummary("pauseKeyInterceptingWithEsc", R.string.lorie_pref_summary_requiresIntercepting);
             setSummary("scaleTouchpad", R.string.lorie_pref_summary_requiresTrackpadAndNative);
+            setSummary("adjustHeightForEK", R.string.lorie_pref_summary_followsReseed);
 
             if (!SamsungDexUtils.available())
                 setVisible("dexMetaKeyCapture", false);
 
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P)
                 setVisible("hideCutout", false);
+
+            // Below R there is no way to tell the soft keyboard is shown but does not overlap us.
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R)
+                setVisible("hideEKBarWithoutIme", false);
 
             boolean stylusAvailable = Arrays.stream(InputDevice.getDeviceIds())
                     .mapToObj(InputDevice::getDevice)
@@ -346,6 +351,8 @@ public class LoriePreferences extends AppCompatActivity implements PreferenceFra
             boolean displayStretchEnabled = "exact".contentEquals(prefs.displayResolutionMode.get()) || "custom".contentEquals(prefs.displayResolutionMode.get());
             setEnabled("displayStretch", displayStretchEnabled);
             setEnabled("adjustResolution", displayStretchEnabled);
+
+            setEnabled("adjustHeightForEK", !prefs.hideEKBarWithoutIme.get());
 
             setEnabled("scaleTouchpad", "1".equals(prefs.touchMode.get()) && !"native".equals(prefs.displayResolutionMode.get()));
             setEnabled("showMouseHelper", "1".equals(prefs.touchMode.get()));

--- a/lorie/src/main/java/com/termux/x11/MainActivity.java
+++ b/lorie/src/main/java/com/termux/x11/MainActivity.java
@@ -554,8 +554,9 @@ public class MainActivity extends AppCompatActivity {
                 Log.v("MainActivity", "Extracting X connection socket.");
                 LorieView.connect(fd.detachFd());
                 finishStartupDraw();
-                getLorieView().triggerCallback();
+                // The extra keys bar claims its space first, so that the size is reported once.
                 clientConnectedStateChanged();
+                getLorieView().triggerCallback();
                 getLorieView().reloadPreferences(prefs);
             } else
                 handler.postDelayed(this::tryConnect, 250);
@@ -655,7 +656,8 @@ public class MainActivity extends AppCompatActivity {
         final ViewPager pager = getTerminalToolbarViewPager();
         ViewGroup parent = (ViewGroup) pager.getParent();
 
-        boolean showNow = !isInPictureInPictureMode && LorieView.connected() && prefs.showAdditionalKbd.get() && prefs.additionalKbdVisible.get();
+        boolean showNow = !isInPictureInPictureMode && LorieView.connected() && prefs.showAdditionalKbd.get()
+                && prefs.additionalKbdVisible.get() && (imeShown || !prefs.hideEKBarWithoutIme.get());
 
         pager.setVisibility(showNow ? View.VISIBLE : View.INVISIBLE);
 
@@ -676,13 +678,18 @@ public class MainActivity extends AppCompatActivity {
                 (TermuxX11ExtraKeys.getExtraKeysInfo() == null ? 0 : TermuxX11ExtraKeys.getExtraKeysInfo().getMatrix().length));
         pager.setLayoutParams(layoutParams);
 
-        ekbarContentInset = prefs.adjustHeightForEK.get() && showNow ? layoutParams.height : 0;
+        // A bar tied to the keyboard follows the screen reseeding of the keyboard itself, so that
+        // the screen either keeps its size or is never covered by the bar.
+        boolean adjustHeight = prefs.hideEKBarWithoutIme.get()
+                ? prefs.Reseed.get() : prefs.adjustHeightForEK.get();
+        ekbarContentInset = adjustHeight && showNow ? layoutParams.height : 0;
         applyContentInsets();
         getLorieView().requestFocus();
     }
 
     private int ekbarContentInset = 0;
     private int imeHeight = 0;
+    private boolean imeShown = false;
     private int captionHeight = 0;
 
     private void applyContentInsets() {
@@ -697,9 +704,14 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    public void setImeHeight(int height) {
+    public void setIme(int height, boolean shown) {
+        boolean affectsExtraKeys = imeShown != shown && prefs.hideEKBarWithoutIme.get();
         imeHeight = height;
-        applyContentInsets();
+        imeShown = shown;
+        if (affectsExtraKeys)
+            setTerminalToolbarView(); // it applies the insets on its own
+        else
+            applyContentInsets();
     }
 
     // The window header of desktop windowing can not be hidden, so its space has to be given up even

--- a/lorie/src/main/java/com/termux/x11/utils/ImeHeightProvider.java
+++ b/lorie/src/main/java/com/termux/x11/utils/ImeHeightProvider.java
@@ -73,11 +73,16 @@ public class ImeHeightProvider {
                 ? insets.getInsets(WindowInsetsCompat.Type.captionBar()).top : 0);
 
         int imeHeight = 0;
+        boolean imeShown = false;
         if (activity.hasWindowFocus() && !SamsungDexUtils.checkDeXEnabled(activity) && !activity.isInPictureInPictureMode()) {
             int navBottom = (insets != null && child.getFitsSystemWindows())
                     ? insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom : 0;
             imeHeight = Math.max(0, bottom - navBottom);
+            // A floating window the keyboard does not overlap gets no height out of it, but the
+            // visibility of the insets does not depend on how much of them reaches the window.
+            imeShown = SDK_INT >= VERSION_CODES.R && insets != null
+                    ? insets.isVisible(WindowInsetsCompat.Type.ime()) : imeHeight > 0;
         }
-        MainActivity.getInstance().setImeHeight(imeHeight);
+        MainActivity.getInstance().setIme(imeHeight, imeShown);
     }
 }

--- a/lorie/src/main/res/values/strings.xml
+++ b/lorie/src/main/res/values/strings.xml
@@ -101,6 +101,8 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="lorie_pref_storeSecondaryDisplayPreferencesSeparately_summary">Open this screen on display you want to configure</string>
 
     <string name="lorie_pref_adjustHeightForEK">Prevent extra keys bar from covering the display</string>
+    <string name="lorie_pref_hideEKBarWithoutIme">Hide extra keys bar with the soft keyboard</string>
+    <string name="lorie_pref_hideEKBarWithoutIme_summary">Show it only while the soft keyboard is shown</string>
     <string name="lorie_pref_useTermuxEKBarBehaviour">Deactivate special keys on additional key bar after each keypress</string>
     <string name="lorie_pref_useTermuxEKBarBehaviour_summary">Use long-tap to lock special keys</string>
     <string name="lorie_pref_opacityEKBar">Opacity of extra keys bar, %</string>
@@ -119,4 +121,5 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="lorie_pref_summary_requiresExactOrCustom">Requires "display resolution mode" to be "exact" or "custom"</string>
     <string name="lorie_pref_summary_requiresIntercepting">Requires intercepting system shortcuts with Dex mode or with Accessibility service</string>
     <string name="lorie_pref_summary_requiresTrackpadAndNative">Requires "Touchscreen input mode" to be "Trackpad" and "Display resolution mode" to be not "native"</string>
+    <string name="lorie_pref_summary_followsReseed">Follows "Reseed screen while soft keyboard is open" while the bar is shown with the soft keyboard</string>
 </resources>

--- a/lorie/src/main/res/xml/preferences.xml
+++ b/lorie/src/main/res/xml/preferences.xml
@@ -61,6 +61,7 @@
     </PreferenceScreen>
     <PreferenceScreen app:key="ekbar">
         <SwitchPreferenceCompat app:key="adjustHeightForEK" app:defaultValue="true" />
+        <SwitchPreferenceCompat app:key="hideEKBarWithoutIme" app:defaultValue="false" />
         <SwitchPreferenceCompat app:key="useTermuxEKBarBehaviour" app:defaultValue="false" />
         <SeekBarPreference app:key="opacityEKBar" app:defaultValue="100" app:min="1" android:max="100" app:seekBarIncrement="1" app:showSeekBarValue="true" app:updatesContinuously="true" />
         <EditTextPreference app:key="extra_keys_config" />


### PR DESCRIPTION
The bar follows the screen reseeding of the keyboard while the preference is on, so that the screen either keeps its size or is never covered by the bar. It is only offered since R, where the visibility of the keyboard is reported even when the keyboard does not overlap the window. The bar also claims its space before the size is first reported now, which used to cost a second mode switch right after the first one.