### PR TITLE
feat(input): sync Caps/Num/Scroll Lock state from Android to X server

### DIFF
--- a/lorie/src/main/cpp/lorie/InputXKB.c
+++ b/lorie/src/main/cpp/lorie/InputXKB.c
@@ -987,3 +987,111 @@ void lorieKeysymKeyboardEvent(KeySym keysym, int down) {
      */
     mieqProcessInputEvents();
 }
+
+/*
+ * Resolves the real modifier mask that a given lock key (Caps_Lock/Num_Lock) actually
+ * locks in the current keymap, the same way a real press of that key would resolve it
+ * (compare lorieIsAffectedByNumLock above), so lorieSyncLockKeysState locks/unlocks
+ * exactly what a real key would.
+ */
+static unsigned lorieGetLockKeyModMask(KeySym sym) {
+	XkbDescPtr xkb;
+	XkbAction *act;
+	KeyCode keycode;
+	unsigned state = lorieGetKeyboardState() & ~0xff;
+
+	keycode = lorieKeysymToKeycode(sym, state, NULL);
+	if (keycode == 0)
+		return 0;
+
+	xkb = GetMaster(lorieKeyboard, KEYBOARD_OR_FLOAT)->key->xkbInfo->desc;
+	act = XkbKeyActionPtr(xkb, keycode, state);
+	if (act == NULL || act->type != XkbSA_LockMods)
+		return 0;
+
+	if (act->mods.flags & XkbSA_UseModMapMods)
+		return xkb->map->modmap[keycode];
+	return act->mods.mask;
+}
+
+/*
+ * Directly flips a locked modifier bit and runs the same bookkeeping a real
+ * key-triggered lock action would (see XkbHandleActions/_XkbFilterLockState in
+ * xkbActions.c), without emulating any key press -- so no spurious KeyPress/KeyRelease
+ * ever reaches clients just because Android's lock key state changed elsewhere.
+ */
+static void lorieSetLockedMods(DeviceIntPtr dev, unsigned mask, Bool on) {
+	XkbSrvInfoPtr xkbi = dev->key->xkbInfo;
+	XkbStateRec old;
+	XkbEventCauseRec cause;
+	xkbStateNotify sn;
+	unsigned changed;
+
+	if (!mask)
+		return;
+
+	old = xkbi->state;
+	if (on)
+		xkbi->state.locked_mods |= mask;
+	else
+		xkbi->state.locked_mods &= ~mask;
+	XkbComputeDerivedState(xkbi);
+
+	changed = XkbStateChangedFlags(&old, &xkbi->state);
+	if (!changed)
+		return;
+
+	XkbSetCauseUnknown(&cause);
+	memset(&sn, 0, sizeof(sn));
+	sn.changed = changed;
+	XkbSendStateNotify(dev, &sn);
+
+	changed = XkbIndicatorsToUpdate(dev, changed, FALSE);
+	if (changed)
+		XkbUpdateIndicators(dev, changed, TRUE, NULL, &cause);
+
+	XkbPushLockedStateToSlaves(dev, 0, 0);
+}
+
+/*
+ * Scroll Lock isn't tied to any real modifier in stock keymaps (unlike Caps/Num Lock),
+ * so there's nothing in locked_mods to flip for it. It's still a regular, explicitly
+ * settable indicator though (compat/led/ledscroll allows it, unlike caps/num), so we
+ * just drive its LED state directly the same way a SetNamedIndicator request would.
+ */
+static void lorieSetScrollLockIndicator(DeviceIntPtr dev, Bool on) {
+	XkbDescPtr xkb = dev->key->xkbInfo->desc;
+	Atom atom;
+	int i;
+
+	if (!xkb->names)
+		return;
+
+	atom = MakeAtom("Scroll Lock", strlen("Scroll Lock"), TRUE);
+	for (i = 0; i < XkbNumIndicators; i++) {
+		if (xkb->names->indicators[i] == atom) {
+			XkbEventCauseRec cause;
+			XkbSetCauseUnknown(&cause);
+			XkbSetIndicators(dev, 1u << i, on ? (1u << i) : 0, &cause);
+			return;
+		}
+	}
+}
+
+/*
+ * Mirrors Android's current Caps/Num/Scroll Lock state onto the X server's XKB state,
+ * e.g. right after regaining focus, when the state may have changed while backgrounded
+ * and unseen by us. Changes server state directly instead of emulating key presses.
+ *
+ * `state` bits must match InputEventSender.syncLockKeysState() on the Java side:
+ * bit0 = Caps Lock, bit1 = Num Lock, bit2 = Scroll Lock.
+ */
+void lorieSyncLockKeysState(uint8_t state) {
+	DeviceIntPtr master = GetMaster(lorieKeyboard, KEYBOARD_OR_FLOAT);
+	if (!master || !master->key || !master->key->xkbInfo)
+		return;
+
+	lorieSetLockedMods(master, lorieGetLockKeyModMask(XK_Caps_Lock), (state & (1u << 0)) != 0);
+	lorieSetLockedMods(master, lorieGetLockKeyModMask(XK_Num_Lock), (state & (1u << 1)) != 0);
+	lorieSetScrollLockIndicator(master, (state & (1u << 2)) != 0);
+}

--- a/lorie/src/main/cpp/lorie/activity.cpp
+++ b/lorie/src/main/cpp/lorie/activity.cpp
@@ -368,6 +368,9 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *vm, __unused void *reserved) {
             {"requestStylusEnabled", "(Z)V", (void *) +[](__unused JNIEnv *env, __unused jclass clazz, jboolean enabled) {
                 sendEvent(.stylusEnable = { .t = EVENT_STYLUS_ENABLE, .enable = enabled });
             }},
+            {"sendLockKeysState", "(I)V", (void *) +[](__unused JNIEnv *env, __unused jclass clazz, jint state) {
+                sendEvent(.lockKeysState = { .t = EVENT_LOCK_KEYS_STATE, .state = (uint8_t) state });
+            }},
             {"sendKeyEvent", "(IIZ)Z", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jint scan_code, jint key_code, jboolean key_down) -> jboolean {
                 if (conn_fd != -1) {
                     int code = (scan_code) ?: android_to_linux_keycode[key_code];

--- a/lorie/src/main/cpp/lorie/cmdentrypoint.cpp
+++ b/lorie/src/main/cpp/lorie/cmdentrypoint.cpp
@@ -411,6 +411,19 @@ void handleLorieEvents(int fd, __unused int ready, __unused void *ignored) {
                 }, nullptr, nullptr);
                 lorieWakeServer();
                 break;
+            case EVENT_LOCK_KEYS_STATE: {
+                auto *copy = (lorieEvent*) calloc(1, sizeof(lorieEvent));
+                memcpy(copy, &e, sizeof(e));
+                QueueWorkProc(+[](__unused ClientPtr pClient, void *closure) -> Bool {
+                    // This must be done only on X server thread (touches XKB state directly).
+                    auto *e = (lorieEvent*) closure;
+                    lorieSyncLockKeysState(e->lockKeysState.state);
+                    free(e);
+                    return TRUE;
+                }, nullptr, copy);
+                lorieWakeServer();
+                break;
+            }
         }
 
         int n;

--- a/lorie/src/main/cpp/lorie/lorie.h
+++ b/lorie/src/main/cpp/lorie/lorie.h
@@ -32,6 +32,7 @@ void lorieRequestClipboard(void);
 void lorieHandleClipboardAnnounce(void);
 void lorieHandleClipboardData(const char* data);
 void lorieSetStylusEnabled(Bool enabled);
+void lorieSyncLockKeysState(uint8_t state);
 void lorieWakeServer(void);
 void lorieRecheckGpuCopies(void);
 void lorieChoreographerFrameCallback(__unused long t, AChoreographer* d);
@@ -106,6 +107,7 @@ typedef enum {
     EVENT_WINDOW_FOCUS_CHANGED,
     EVENT_RENDERER_WAKEUP_COND,
     EVENT_GPU_COPY_DONE,
+    EVENT_LOCK_KEYS_STATE,
 } eventType;
 
 typedef union {
@@ -157,6 +159,10 @@ typedef union {
         uint8_t t;
         uint32_t count;
     } clipboardSend;
+    struct {
+        uint8_t t;
+        uint8_t state; // bit0 = Caps Lock, bit1 = Num Lock, bit2 = Scroll Lock
+    } lockKeysState;
 } lorieEvent;
 
 typedef struct { int16_t x1, y1, x2, y2; } LorieGpuCopyRect;

--- a/lorie/src/main/java/com/termux/x11/LorieView.java
+++ b/lorie/src/main/java/com/termux/x11/LorieView.java
@@ -690,6 +690,7 @@ public class LorieView extends SurfaceView implements InputStub {
     @FastNative public native void sendTouchEvent(int action, int id, int x, int y);
     @FastNative public native void sendStylusEvent(float x, float y, int pressure, int tiltX, int tiltY, int orientation, int buttons, boolean eraser, boolean mouseMode);
     @FastNative static public native void requestStylusEnabled(boolean enabled);
+    @FastNative public native void sendLockKeysState(int state);
     @FastNative public native boolean sendKeyEvent(int scanCode, int keyCode, boolean keyDown);
     @FastNative public native void sendTextEvent(byte[] text);
     @CriticalNative public static native boolean requestConnection();

--- a/lorie/src/main/java/com/termux/x11/input/InputEventSender.java
+++ b/lorie/src/main/java/com/termux/x11/input/InputEventSender.java
@@ -45,6 +45,9 @@ public final class InputEventSender {
     private final TreeSet<Integer> mPressedTextKeys;
     private final TreeSet<Integer> mPressedKeys;
 
+    /** Last Caps/Num/Scroll Lock state sent to the host, or -1 if none has been sent yet. */
+    private int mLockKeysState = -1;
+
     public InputEventSender(InputStub injector) {
         if (injector == null)
             throw new NullPointerException();
@@ -78,6 +81,23 @@ public final class InputEventSender {
                         mInjector.sendKeyEvent(0, mod[i], false);
                 }
             }
+        }
+    }
+
+    /**
+     * Mirrors Android's current Caps/Num/Scroll Lock state onto the host, e.g. after regaining
+     * focus with the state possibly having changed while backgrounded. Every KeyEvent and
+     * MotionEvent carries the current state in its metaState regardless of which key or pointer
+     * action it represents, so callers can just forward it on every real (non-synthetic) event;
+     * this only actually notifies the host when the state actually changed.
+     */
+    public void syncLockKeysState(int eventMetaState) {
+        int state = (((eventMetaState & META_CAPS_LOCK_ON) != 0) ? 1 : 0)
+                | (((eventMetaState & META_NUM_LOCK_ON) != 0) ? 2 : 0)
+                | (((eventMetaState & META_SCROLL_LOCK_ON) != 0) ? 4 : 0);
+        if (state != mLockKeysState) {
+            mLockKeysState = state;
+            mInjector.sendLockKeysState(state);
         }
     }
 
@@ -177,6 +197,9 @@ public final class InputEventSender {
     public boolean sendKeyEvent(KeyEvent e) {
         int keyCode = e.getKeyCode();
         boolean pressed = e.getAction() == KeyEvent.ACTION_DOWN;
+
+        if (e.getDeviceId() >= 0)
+            syncLockKeysState(e.getMetaState());
 
         if ((e.getFlags() & KeyEvent.FLAG_CANCELED) == KeyEvent.FLAG_CANCELED) {
             android.util.Log.d("KeyEvent", "We've got key event with FLAG_CANCELED, it will not be consumed. Details: " + e);

--- a/lorie/src/main/java/com/termux/x11/input/InputStub.java
+++ b/lorie/src/main/java/com/termux/x11/input/InputStub.java
@@ -42,4 +42,7 @@ public interface InputStub {
     void sendTouchEvent(int action, int pointerId, int x, int y);
 
     void sendStylusEvent(float x, float y, int pressure, int tiltX, int tiltY, int orientation, int buttons, boolean eraser, boolean mouseMode);
+
+    /** Mirrors Android's current Caps/Num/Scroll Lock state onto the remote host's keyboard state. */
+    void sendLockKeysState(int state);
 }

--- a/lorie/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/lorie/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -283,8 +283,10 @@ public class TouchInputHandler {
         if (ignoreGamepadEvents && (event.isFromSource(InputDevice.SOURCE_GAMEPAD) || event.isFromSource(InputDevice.SOURCE_JOYSTICK)))
             return true;
 
-        if (event.getDeviceId() >= 0)
+        if (event.getDeviceId() >= 0) {
             mInjector.releaseStuckModifiers(event.getMetaState());
+            mInjector.syncLockKeysState(event.getMetaState());
+        }
 
         // Regular touchpads and Dex touchpad (in captured mode) send events as finger too,
         // but they should be handled as touchscreens with trackpad mode.


### PR DESCRIPTION
Forwards the lock-key bits from every real KeyEvent/MotionEvent's metaState to the X server, so toggling them while termux-x11 was backgrounded (and unseen by us) gets picked up as soon as focus returns. The server applies the state directly to XKB (locked_mods for Caps/Num, the indicator for Scroll Lock, which isn't tied to a real modifier in stock keymaps) instead of emulating key presses, so no spurious KeyPress/KeyRelease reaches clients.