### PR TITLE
refactor(lorie): tie native LorieView resources to the Java view's own lifecycle

### DIFF
--- a/lorie/src/main/cpp/lorie/activity.cpp
+++ b/lorie/src/main/cpp/lorie/activity.cpp
@@ -15,15 +15,16 @@
 #include <linux/in.h>
 #include <arpa/inet.h>
 #include <poll.h>
+#include <new>
 #include "lorie.h"
 
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma ide diagnostic ignored "cppcoreguidelines-narrowing-conversions"
 #pragma ide diagnostic ignored "ConstantFunctionResult"
 #define log(prio, ...) __android_log_print(ANDROID_LOG_ ## prio, "LorieNative", __VA_ARGS__)
-#define sendEvent(...) do { if (conn_fd != -1) { lorieEvent e = { __VA_ARGS__ }; write(conn_fd, &e, sizeof(e)); } } while (0)
+// `r` must be a LorieViewResources* — the connection fd is per-instance state, not a process global.
+#define sendEvent(r, ...) do { if ((r) && (r)->connFd != -1) { lorieEvent e = { __VA_ARGS__ }; write((r)->connFd, &e, sizeof(e)); } } while (0)
 
-extern volatile int conn_fd; // The only variable from shared with X server code.
 bool lorieDebugEnabled = false;
 
 // Timestamp of the last real input reaching the X session, from any source. Read/written only
@@ -52,9 +53,20 @@ static struct {
     jmethodID toString;
 } CharBuffer = {0};
 
-static JNIEnv *guienv = NULL; // Must be used only in GUI thread.
-static jobject globalThiz = NULL;
-static Renderer g_renderer;
+// Bundles the native state belonging to the current LorieView instance so it can be released
+// as a unit when that instance is torn down, instead of leaking as scattered process globals.
+struct LorieViewResources {
+    Renderer renderer;
+    JNIEnv* env = NULL;    // GUI-thread JNIEnv. Must be used only in GUI thread.
+    jobject thiz = NULL;   // global ref to the owning LorieView
+    volatile int connFd = -1;
+    bool destroyed = true;
+
+    LorieViewResources(JNIEnv* callerEnv, jobject view);
+    ~LorieViewResources();
+    void connect(jint fd);
+    int xcallback(int fd, int events);
+};
 
 static jclass FindClassOrDie(JNIEnv *env, const char* name) {
     jclass clazz = env->FindClass(name);
@@ -82,7 +94,7 @@ static jmethodID FindMethodOrDie(JNIEnv *env, jclass clazz, const char* name, co
     return method;
 }
 
-static jboolean requestConnection(__unused JNIEnv *env, __unused jclass clazz) {
+static jboolean requestConnection(__unused jlong ptr) {
 #define check(cond, fmt, ...) if ((cond)) do { __android_log_print(ANDROID_LOG_ERROR, "requestConnection", fmt, ## __VA_ARGS__); goto end; } while (0)
     bool sent = JNI_FALSE;
     // We do not want to block GUI thread for a long time so we will set timeout to 20 msec.
@@ -118,9 +130,7 @@ static jboolean requestConnection(__unused JNIEnv *env, __unused jclass clazz) {
 #undef errorReturn
 }
 
-static void connect_(__unused JNIEnv* env, __unused jobject cls, jint fd);
-static void nativeInit(JNIEnv *env, jobject thiz) {
-    JavaVM* vm;
+static jlong nativeInit(JNIEnv *env, jobject thiz) {
     if (!Charset.self) {
         // Init clipboard-related JNI stuff
         Charset.self = FindClassOrDie(env, "java/nio/charset/Charset");
@@ -136,44 +146,65 @@ static void nativeInit(JNIEnv *env, jobject thiz) {
         MainActivity.resetIme = FindMethodOrDie(env, env->GetObjectClass(thiz), "resetIme", "()V", JNI_FALSE);
     }
 
-    g_renderer.init(env);
-
-    env->GetJavaVM(&vm);
-    vm->AttachCurrentThread(&guienv, NULL);
-    globalThiz = guienv->NewGlobalRef(thiz);
-    connect_(NULL, NULL, -1);
+    return (jlong) (intptr_t) new (malloc(sizeof(LorieViewResources))) LorieViewResources(env, thiz);
 }
 
-static int xcallback(int fd, int events, __unused void* data) {
-    JNIEnv *env = guienv;
-    jobject thiz = globalThiz;
+LorieViewResources::LorieViewResources(JNIEnv *callerEnv, jobject view) {
+    JavaVM* vm;
+    destroyed = false;
+    renderer.init(callerEnv);
+    renderer.connFdPtr = &connFd; // lets the renderer thread wake up a GPU copy waiter
 
+    callerEnv->GetJavaVM(&vm);
+    vm->AttachCurrentThread(&env, NULL);
+    thiz = env->NewGlobalRef(view);
+    connect(-1);
+}
+
+LorieViewResources::~LorieViewResources() {
+    destroyed = true;
+
+    if (connFd != -1) {
+        ALooper_removeFd(ALooper_forThread(), connFd);
+        close(connFd);
+        connFd = -1;
+    }
+
+    renderer.destroy();
+
+    if (thiz) {
+        env->DeleteGlobalRef(thiz);
+        thiz = NULL;
+    }
+}
+
+int LorieViewResources::xcallback(int fd, int events) {
     if (events & (ALOOPER_EVENT_ERROR | ALOOPER_EVENT_HANGUP)) {
         jobject instance = env->CallStaticObjectMethod(MainActivity.self, MainActivity.getInstance);
         if (instance)
             env->CallVoidMethod(instance, MainActivity.clientConnectedStateChanged);
 
         ALooper_removeFd(ALooper_forThread(), fd);
-        close(conn_fd);
-        conn_fd = -1;
-        g_renderer.setSharedState(NULL);
-        g_renderer.removeAllBuffers();
+        close(connFd);
+        connFd = -1;
+        renderer.setSharedState(NULL);
+        renderer.removeAllBuffers();
         log(DEBUG, "disconnected");
         return 1;
     }
 
-    if (conn_fd != -1) {
+    if (connFd != -1) {
         lorieEvent e = {0};
 
         again:
-        if (read(conn_fd, &e, sizeof(e)) == sizeof(e)) {
+        if (read(connFd, &e, sizeof(e)) == sizeof(e)) {
             switch(e.type) {
                 case EVENT_CLIPBOARD_SEND: {
                     if (!e.clipboardSend.count)
                         break;
                     char clipboard[e.clipboardSend.count + 1];
                     memset(clipboard, 0, e.clipboardSend.count + 1);
-                    read(conn_fd, clipboard, sizeof(clipboard));
+                    read(connFd, clipboard, sizeof(clipboard));
                     clipboard[e.clipboardSend.count] = 0;
                     log(DEBUG, "Clipboard content (%zu symbols) is %s", strlen(clipboard), clipboard);
                     jmethodID id = env->GetMethodID(env->GetObjectClass(thiz), "setClipboardText","(Ljava/lang/String;)V");
@@ -192,7 +223,7 @@ static int xcallback(int fd, int events, __unused void* data) {
                 }
                 case EVENT_SHARED_SERVER_STATE: {
                     struct lorie_shared_server_state* state = NULL;
-                    int stateFd = ancil_recv_fd(conn_fd);
+                    int stateFd = ancil_recv_fd(connFd);
 
                     if (stateFd < 0)
                         break;
@@ -203,7 +234,7 @@ static int xcallback(int fd, int events, __unused void* data) {
                         state = NULL;
                     }
 
-                    g_renderer.setSharedState(state);
+                    renderer.setSharedState(state);
 
                     close(stateFd); // Closing file descriptor does not unmmap shared memory fragment.
                     break;
@@ -211,14 +242,14 @@ static int xcallback(int fd, int events, __unused void* data) {
                 case EVENT_ADD_BUFFER: {
                     static LorieBuffer* buffer = NULL;
                     const LorieBuffer_Desc* desc;
-                    LorieBuffer_recvHandleFromUnixSocket(conn_fd, &buffer);
+                    LorieBuffer_recvHandleFromUnixSocket(connFd, &buffer);
                     desc = LorieBuffer_description(buffer);
                     log(INFO, "Received shared buffer width %d stride %d height %d format %d type %d id %llu", desc->width, desc->stride, desc->height, desc->format, desc->type, desc->id);
-                    g_renderer.addBuffer(buffer);
+                    renderer.addBuffer(buffer);
                     break;
                 }
                 case EVENT_REMOVE_BUFFER: {
-                    g_renderer.removeBuffer(e.removeBuffer.id);
+                    renderer.removeBuffer(e.removeBuffer.id);
                     break;
                 }
                 case EVENT_WINDOW_FOCUS_CHANGED: {
@@ -228,35 +259,36 @@ static int xcallback(int fd, int events, __unused void* data) {
         }
 
         int n;
-        if (ioctl(conn_fd, FIONREAD, &n) >= 0 && n > sizeof(e))
+        if (ioctl(connFd, FIONREAD, &n) >= 0 && n > sizeof(e))
             goto again;
     }
 
     return 1;
 }
 
-static void connect_(__unused JNIEnv* env, __unused jobject cls, jint fd) {
-    if (conn_fd != -1) {
-        ALooper_removeFd(ALooper_forThread(), conn_fd);
-        close(conn_fd);
-        g_renderer.setSharedState(NULL);
-        g_renderer.removeAllBuffers();
+void LorieViewResources::connect(jint fd) {
+    if (connFd != -1) {
+        ALooper_removeFd(ALooper_forThread(), connFd);
+        close(connFd);
+        renderer.setSharedState(NULL);
+        renderer.removeAllBuffers();
         log(DEBUG, "disconnected");
     }
 
-    if ((conn_fd = fd) != -1) {
-        ALooper_addFd(ALooper_forThread(), fd, 0, ALOOPER_EVENT_INPUT | ALOOPER_EVENT_ERROR | ALOOPER_EVENT_HANGUP, xcallback, NULL);
+    if ((connFd = fd) != -1) {
+        ALooper_addFd(ALooper_forThread(), fd, 0, ALOOPER_EVENT_INPUT | ALOOPER_EVENT_ERROR | ALOOPER_EVENT_HANGUP,
+                      +[](int fd, int events, void* data) -> int { return ((LorieViewResources*) data)->xcallback(fd, events); }, this);
 
         // Give the X server our renderer wakeup cond var fd, resent on every reconnect.
         lorieEvent e = { .type = EVENT_RENDERER_WAKEUP_COND };
-        write(conn_fd, &e, sizeof(e));
-        ancil_send_fd(conn_fd, g_renderer.getWakeupCondFd());
+        write(connFd, &e, sizeof(e));
+        ancil_send_fd(connFd, renderer.getWakeupCondFd());
 
         log(DEBUG, "XCB connection is successfull");
     }
 }
 
-static void startLogcat(JNIEnv *env, __unused jobject cls, jint fd) {
+static void startLogcat(JNIEnv *env, __unused jclass clazz, __unused jlong ptr, jint fd) {
     log(DEBUG, "Starting logcat with output to given fd");
     lorieDebugEnabled = true;
 
@@ -276,9 +308,10 @@ static void startLogcat(JNIEnv *env, __unused jobject cls, jint fd) {
     }
 }
 
-static void sendTextEvent(JNIEnv *env, __unused jobject thiz, jbyteArray text) {
+static void sendTextEvent(JNIEnv *env, __unused jobject thiz, jlong ptr, jbyteArray text) {
     lastInputTimestampMs = nowMs();
-    if (conn_fd != -1 && text) {
+    auto* r = (LorieViewResources*) ptr;
+    if (r && r->connFd != -1 && text) {
         jsize length = env->GetArrayLength(text);
         jbyte *str = env->GetByteArrayElements(text, NULL);
         char *p = (char*) str;
@@ -302,7 +335,7 @@ static void sendTextEvent(JNIEnv *env, __unused jobject thiz, jbyteArray text) {
 
             log(DEBUG, "Sending unicode event: %lc (U+%X)", wc, wc);
             lorieEvent e = { .unicode = { .t = EVENT_UNICODE, .code = (uint32_t) wc } };
-            write(conn_fd, &e, sizeof(e));
+            write(r->connFd, &e, sizeof(e));
             p += len;
             if (p - (char*) str >= length)
                 break;
@@ -316,85 +349,115 @@ static void sendTextEvent(JNIEnv *env, __unused jobject thiz, jbyteArray text) {
 JNIEXPORT jint JNI_OnLoad(JavaVM *vm, __unused void *reserved) {
     JNIEnv* env;
     static JNINativeMethod methods[] = {
-            {"nativeInit", "()V", (void *)&nativeInit},
-            {"surfaceChanged", "(Landroid/view/Surface;)V", (void *) +[](JNIEnv *env, __unused jobject thiz, jobject sfc) {
-                g_renderer.setWindow(env, sfc);
+            {"nativeInit", "()J", (void *)&nativeInit},
+            {"nativeDestroy", "(J)V", (void *) +[](__unused JNIEnv *env, __unused jobject thiz, jlong ptr) {
+                auto* r = (LorieViewResources*) ptr;
+                if (!r) return;
+                r->~LorieViewResources();
+                free(r);
             }},
-            {"setViewport", "(IIIIIII)V", (void *) +[](__unused JNIEnv *env, __unused jclass clazz, jint x, jint y, jint w, jint h, jint ew, jint eh, jint hidden) {
-                g_renderer.setViewport(x, y, w, h, ew, eh, hidden);
+            {"surfaceChanged", "(JLandroid/view/Surface;)V", (void *) +[](JNIEnv *env, __unused jobject thiz, jlong ptr, jobject sfc) {
+                auto* r = (LorieViewResources*) ptr;
+                if (!r || r->destroyed) return;
+                r->renderer.setWindow(env, sfc);
             }},
-            {"setRendererZoom", "(I)V", (void *) +[](__unused JNIEnv *env, __unused jclass clazz, jint percent) {
-                g_renderer.setZoom(percent);
+            {"setViewport", "(JIIIIIII)V", (void *) +[](__unused JNIEnv *env, __unused jobject thiz, jlong ptr, jint x, jint y, jint w, jint h, jint ew, jint eh, jint hidden) {
+                auto* r = (LorieViewResources*) ptr;
+                if (!r || r->destroyed) return;
+                r->renderer.setViewport(x, y, w, h, ew, eh, hidden);
             }},
-            {"setFiltering", "(I)V", (void *) +[](__unused JNIEnv* env, __unused jobject self, jint filtering) {
-                g_renderer.setFiltering(filtering);
+            {"setRendererZoom", "(JI)V", (void *) +[](__unused JNIEnv *env, __unused jobject thiz, jlong ptr, jint percent) {
+                auto* r = (LorieViewResources*) ptr;
+                if (!r || r->destroyed) return;
+                r->renderer.setZoom(percent);
             }},
-            {"connect", "(I)V", (void *)&connect_},
-            {"connected", "()Z", (void *) +[](__unused JNIEnv* env, __unused jclass clazz) -> jboolean {
-                return conn_fd != -1;
+            {"setFiltering", "(JI)V", (void *) +[](__unused JNIEnv* env, __unused jobject self, jlong ptr, jint filtering) {
+                auto* r = (LorieViewResources*) ptr;
+                if (!r || r->destroyed) return;
+                r->renderer.setFiltering(filtering);
             }},
-            {"startLogcat", "(I)V", (void *)&startLogcat},
-            {"setClipboardSyncEnabled", "(ZZ)V", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jboolean enable, __unused jboolean ignored) {
-                sendEvent(.clipboardEnable = { .t = EVENT_CLIPBOARD_ENABLE, .enable = enable });
+            {"connect", "(JI)V", (void *) +[](__unused JNIEnv* env, __unused jclass clazz, jlong ptr, jint fd) {
+                auto* r = (LorieViewResources*) ptr;
+                if (!r) return;
+                r->connect(fd);
             }},
-            {"sendClipboardAnnounce", "()V", (void *) +[](__unused JNIEnv *env, __unused jobject thiz) {
-                sendEvent(.type = EVENT_CLIPBOARD_ANNOUNCE);
+            // @CriticalNative: no implicit JNIEnv*/jclass, unlike the @FastNative entries below.
+            {"connected", "(J)Z", (void *) +[](jlong ptr) -> jboolean {
+                auto* r = (LorieViewResources*) ptr;
+                return r && r->connFd != -1;
             }},
-            {"sendClipboardEvent", "([B)V", (void *) +[](JNIEnv *env, __unused jobject thiz, jbyteArray text) {
-                if (conn_fd != -1 && text) {
+            {"startLogcat", "(JI)V", (void *)&startLogcat},
+            {"setClipboardSyncEnabled", "(JZZ)V", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jlong ptr, jboolean enable, __unused jboolean ignored) {
+                auto* r = (LorieViewResources*) ptr;
+                sendEvent(r, .clipboardEnable = { .t = EVENT_CLIPBOARD_ENABLE, .enable = enable });
+            }},
+            {"sendClipboardAnnounce", "(J)V", (void *) +[](__unused JNIEnv *env, __unused jobject thiz, jlong ptr) {
+                auto* r = (LorieViewResources*) ptr;
+                sendEvent(r, .type = EVENT_CLIPBOARD_ANNOUNCE);
+            }},
+            {"sendClipboardEvent", "(J[B)V", (void *) +[](JNIEnv *env, __unused jobject thiz, jlong ptr, jbyteArray text) {
+                auto* r = (LorieViewResources*) ptr;
+                if (r && r->connFd != -1 && text) {
                     jsize length = env->GetArrayLength(text);
                     jbyte* str = env->GetByteArrayElements(text, NULL);
-                    sendEvent(.clipboardSend = { .t = EVENT_CLIPBOARD_SEND, .count = (uint32_t) length });
-                    write(conn_fd, str, length);
+                    sendEvent(r, .clipboardSend = { .t = EVENT_CLIPBOARD_SEND, .count = (uint32_t) length });
+                    write(r->connFd, str, length);
                     env->ReleaseByteArrayElements(text, str, JNI_ABORT);
                 }
             }},
-            {"sendWindowChange", "(IIILjava/lang/String;)V", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jint width, jint height, jint framerate, jstring jname) {
-                if (conn_fd != -1) {
+            {"sendWindowChange", "(JIIILjava/lang/String;)V", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jlong ptr, jint width, jint height, jint framerate, jstring jname) {
+                auto* r = (LorieViewResources*) ptr;
+                if (r && r->connFd != -1) {
                     const char *name = (!jname || width <= 0 || height <= 0) ? NULL : env->GetStringUTFChars(jname, JNI_FALSE);
-                    sendEvent(.screenSize = { .t = EVENT_SCREEN_SIZE, .width = (uint16_t) width, .height = (uint16_t) height, .framerate = (uint16_t) framerate, .name_size = (name ? strlen(name) : 0) });
+                    sendEvent(r, .screenSize = { .t = EVENT_SCREEN_SIZE, .width = (uint16_t) width, .height = (uint16_t) height, .framerate = (uint16_t) framerate, .name_size = (name ? strlen(name) : 0) });
                     if (name) {
-                        write(conn_fd, name, strlen(name));
+                        write(r->connFd, name, strlen(name));
                         env->ReleaseStringUTFChars(jname, name);
                     }
                 }
             }},
-            {"sendMouseEvent", "(FFIZZ)V", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jfloat x, jfloat y, jint which_button, jboolean button_down, jboolean relative) {
+            {"sendMouseEvent", "(JFFIZZ)V", (void *) +[](JNIEnv* env, __unused jobject cls, jlong ptr, jfloat x, jfloat y, jint which_button, jboolean button_down, jboolean relative) {
                 lastInputTimestampMs = nowMs();
-                if (conn_fd != -1) {
+                auto* r = (LorieViewResources*) ptr;
+                if (r && r->connFd != -1) {
                     if (which_button > 0)
-                        env->CallVoidMethod(globalThiz, MainActivity.resetIme);
-                    sendEvent(.mouse = { .t = EVENT_MOUSE, .x = x, .y = y, .detail = (uint8_t) which_button, .down = button_down, .relative = relative });
+                        env->CallVoidMethod(r->thiz, MainActivity.resetIme);
+                    sendEvent(r, .mouse = { .t = EVENT_MOUSE, .x = x, .y = y, .detail = (uint8_t) which_button, .down = button_down, .relative = relative });
                 }
             }},
-            {"sendTouchEvent", "(IIII)V", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jint action, jint id, jint x, jint y) {
+            {"sendTouchEvent", "(JIIII)V", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jlong ptr, jint action, jint id, jint x, jint y) {
                 lastInputTimestampMs = nowMs();
+                auto* r = (LorieViewResources*) ptr;
                 if (action != -1)
-                    sendEvent(.touch = { .t = EVENT_TOUCH, .type = (uint16_t) action, .id = (uint16_t) id, .x = (uint16_t) x, .y = (uint16_t) y });
+                    sendEvent(r, .touch = { .t = EVENT_TOUCH, .type = (uint16_t) action, .id = (uint16_t) id, .x = (uint16_t) x, .y = (uint16_t) y });
             }},
-            {"sendStylusEvent", "(FFIIIIIZZ)V", (void *) +[](__unused JNIEnv *env, __unused jobject thiz, jfloat x, jfloat y, jint pressure, jint tilt_x, jint tilt_y, jint orientation, jint buttons, jboolean eraser, jboolean mouse) {
+            {"sendStylusEvent", "(JFFIIIIIZZ)V", (void *) +[](JNIEnv *env, __unused jobject thiz, jlong ptr, jfloat x, jfloat y, jint pressure, jint tilt_x, jint tilt_y, jint orientation, jint buttons, jboolean eraser, jboolean mouse) {
                 lastInputTimestampMs = nowMs();
-                if (conn_fd != -1) {
-                    env->CallVoidMethod(globalThiz, MainActivity.resetIme);
-                    sendEvent(.stylus = { .t = EVENT_STYLUS, .x = x, .y = y, .pressure = (uint16_t) pressure, .tilt_x = (int8_t) tilt_x, .tilt_y = (int8_t) tilt_y, .orientation = (int16_t) orientation, .buttons = (uint8_t) buttons, .eraser = eraser, .mouse = mouse });
+                auto* r = (LorieViewResources*) ptr;
+                if (r && r->connFd != -1) {
+                    env->CallVoidMethod(r->thiz, MainActivity.resetIme);
+                    sendEvent(r, .stylus = { .t = EVENT_STYLUS, .x = x, .y = y, .pressure = (uint16_t) pressure, .tilt_x = (int8_t) tilt_x, .tilt_y = (int8_t) tilt_y, .orientation = (int16_t) orientation, .buttons = (uint8_t) buttons, .eraser = eraser, .mouse = mouse });
                 }
             }},
-            {"requestStylusEnabled", "(Z)V", (void *) +[](__unused JNIEnv *env, __unused jclass clazz, jboolean enabled) {
-                sendEvent(.stylusEnable = { .t = EVENT_STYLUS_ENABLE, .enable = enabled });
+            {"requestStylusEnabled", "(JZ)V", (void *) +[](__unused JNIEnv *env, __unused jobject thiz, jlong ptr, jboolean enabled) {
+                auto* r = (LorieViewResources*) ptr;
+                sendEvent(r, .stylusEnable = { .t = EVENT_STYLUS_ENABLE, .enable = enabled });
             }},
-            {"sendLockKeysState", "(I)V", (void *) +[](__unused JNIEnv *env, __unused jclass clazz, jint state) {
-                sendEvent(.lockKeysState = { .t = EVENT_LOCK_KEYS_STATE, .state = (uint8_t) state });
+            {"sendLockKeysState", "(JI)V", (void *) +[](__unused JNIEnv *env, __unused jobject thiz, jlong ptr, jint state) {
+                auto* r = (LorieViewResources*) ptr;
+                sendEvent(r, .lockKeysState = { .t = EVENT_LOCK_KEYS_STATE, .state = (uint8_t) state });
             }},
-            {"sendKeyEvent", "(IIZ)Z", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jint scan_code, jint key_code, jboolean key_down) -> jboolean {
+            {"sendKeyEvent", "(JIIZ)Z", (void *) +[](__unused JNIEnv* env, __unused jobject cls, jlong ptr, jint scan_code, jint key_code, jboolean key_down) -> jboolean {
                 lastInputTimestampMs = nowMs();
-                if (conn_fd != -1) {
+                auto* r = (LorieViewResources*) ptr;
+                if (r && r->connFd != -1) {
                     int code = (scan_code) ?: android_to_linux_keycode[key_code];
-                    sendEvent(.key = { .t = EVENT_KEY, .key = (uint16_t) (code + 8), .state = key_down });
+                    sendEvent(r, .key = { .t = EVENT_KEY, .key = (uint16_t) (code + 8), .state = key_down });
                 }
                 return true;
             }},
-            {"sendTextEvent", "([B)V", (void *)&sendTextEvent},
-            {"requestConnection", "()Z", (void *)&requestConnection},
+            {"sendTextEvent", "(J[B)V", (void *)&sendTextEvent},
+            {"requestConnection", "(J)Z", (void *)&requestConnection},
             {"getLastInputTimestamp", "()J", (void *) +[](__unused JNIEnv* env, __unused jclass clazz) -> jlong {
                 return (jlong) lastInputTimestampMs;
             }},

--- a/lorie/src/main/cpp/lorie/cmdentrypoint.cpp
+++ b/lorie/src/main/cpp/lorie/cmdentrypoint.cpp
@@ -35,7 +35,7 @@ extern "C" {
 
 static int argc = 0;
 static char** argv = nullptr;
-__LIBC_HIDDEN__ volatile int conn_fd = -1; // The only variable shared with activity code.
+__LIBC_HIDDEN__ volatile int conn_fd = -1;
 extern DeviceIntPtr lorieMouse, lorieTouch, lorieKeyboard, loriePen, lorieEraser;
 extern ScreenPtr pScreenPtr;
 extern "C" int ucs2keysym(long ucs);

--- a/lorie/src/main/cpp/lorie/lorie.h
+++ b/lorie/src/main/cpp/lorie/lorie.h
@@ -259,6 +259,8 @@ struct Renderer {
     struct xorg_list addedBuffers, buffers, removedBuffers;
     volatile jint filtering = GL_NEAREST;
 
+    pthread_t thread = 0;
+    volatile bool stopping = false;
     volatile bool stateChanged = false, windowChanged = false, viewportChanged = false;
     struct lorie_shared_server_state* pendingState = nullptr;
     ANativeWindow* pendingWin = nullptr;
@@ -309,7 +311,10 @@ struct Renderer {
     uint64_t dstSizeLogCount = 0, srcSizeLogCount = 0;
     uint64_t lastRequestedBufferId = 0;
 
+    volatile int* connFdPtr = nullptr;
+
     void init(JNIEnv* env);
+    void destroy();
     void* initThread();
     int getWakeupCondFd() const;
     void setFiltering(jint f);
@@ -330,6 +335,7 @@ struct Renderer {
     bool shouldWait(bool* waitingForBuffers);
     void threadLoop();
     void bindTexture(GLuint id) const;
+    void notifyGpuCopyDone();
     void reportViewport(int dstX, int dstY, int dstW, int dstH, float left, float top, float width, float height);
     void drawRegion(GLuint id, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, uint8_t flip);
     void drawCursor(float displayWidth, float displayHeight, float sourceLeft, float sourceTop);

--- a/lorie/src/main/cpp/lorie/renderer.cpp
+++ b/lorie/src/main/cpp/lorie/renderer.cpp
@@ -120,14 +120,12 @@ static const char vertexShaderSrc[] =
 static const char fragmentShaderSrc[] = FRAGMENT_SHADER();
 static const char fragmentShaderBgraSrc[] = FRAGMENT_SHADER(".bgra");
 
-// The renderer's end of activity.c's socket to the X server; used to notify it immediately when a
-// GPU copy batch finishes instead of it waiting for the next vblank-tick poll.
-extern "C" volatile int conn_fd;
-
-static void notifyGpuCopyDone() {
-    if (conn_fd != -1) {
+// Notifies activity.cpp's end of the GUI<->X server socket immediately when a GPU copy batch
+// finishes, instead of it waiting for the next vblank-tick poll.
+void Renderer::notifyGpuCopyDone() {
+    if (connFdPtr && *connFdPtr != -1) {
         lorieEvent e = { .type = EVENT_GPU_COPY_DONE };
-        write(conn_fd, &e, sizeof(e));
+        write(*connFdPtr, &e, sizeof(e));
     }
 }
 
@@ -290,8 +288,6 @@ void* Renderer::initThread() {
 }
 
 void Renderer::init(JNIEnv* env) {
-    pthread_t t;
-
     if (ctx)
         return;
 
@@ -317,9 +313,24 @@ void Renderer::init(JNIEnv* env) {
     pthread_cond_init(&stateChangeFinishCond, nullptr);
     pthread_spin_init(&bufferLock, false);
 
-    pthread_create(&t, nullptr, +[](void* cookie) -> void* {
+    stopping = false;
+    pthread_create(&thread, nullptr, +[](void* cookie) -> void* {
         return ((Renderer*) cookie)->initThread();
     }, this);
+}
+
+void Renderer::destroy() {
+    if (!ctx)
+        return; // never initialized, or already destroyed
+
+    pthread_mutex_lock(&stateLock);
+    stopping = true;
+    pthread_cond_signal(stateCond);
+    pthread_mutex_unlock(&stateLock);
+
+    pthread_join(thread, nullptr);
+    thread = 0;
+    ctx = EGL_NO_CONTEXT; // re-passes init()'s `if (ctx) return;` guard for a future re-init
 }
 
 int Renderer::getWakeupCondFd() const {
@@ -1045,9 +1056,11 @@ bool Renderer::shouldWait(bool *waitingForBuffers) {
 void Renderer::threadLoop() {
     LorieBuffer* buf;
     bool waitingForBuffers = false;
-    while (true) {
-        while (shouldWait(&waitingForBuffers))
+    while (!stopping) {
+        while (!stopping && shouldWait(&waitingForBuffers))
             pthread_cond_wait(stateCond, &stateLock);
+        if (stopping)
+            break;
 
         if (stateChanged) {
             struct lorie_shared_server_state* oldState = nullptr;
@@ -1102,6 +1115,34 @@ void Renderer::threadLoop() {
         pthread_spin_unlock(&bufferLock);
         pthread_mutex_lock(&stateLock);
     }
+    pthread_mutex_unlock(&stateLock);
+
+    // Runs on the renderer thread: safe to touch GL/EGL here, they are thread-affine.
+    removeAllBuffers();
+    pthread_spin_lock(&bufferLock);
+    while ((buf = LorieBufferList_first(&removedBuffers)))
+        LorieBuffer_release(buf);
+    pthread_spin_unlock(&bufferLock);
+
+    if (state) {
+        munmap(state, sizeof(*state));
+        state = nullptr;
+    }
+
+    glDeleteProgram(g_texture_program);
+    glDeleteProgram(g_texture_program_bgra);
+    glDeleteTextures(1, &cursor.id);
+    eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    if (sfc != defaultSfc) // defensive; setWindow(nullptr) already reverts this before onDetachedFromWindow runs
+        eglDestroySurface(egl_display, sfc);
+    eglDestroySurface(egl_display, defaultSfc);
+    eglDestroyContext(egl_display, ctx);
+    // Intentionally not calling eglTerminate(egl_display): the EGLDisplay is a process-wide
+    // driver connection, not a per-instance resource.
+    ANativeWindow_release(defaultWin);
+    munmap(stateCond, sizeof(pthread_cond_t));
+    close(stateCondFd);
+    jvm->DetachCurrentThread();
 }
 
 static GLuint loadShader(GLenum shaderType, const char* pSource) {

--- a/lorie/src/main/java/com/termux/x11/LorieView.java
+++ b/lorie/src/main/java/com/termux/x11/LorieView.java
@@ -61,6 +61,7 @@ public class LorieView extends SurfaceView implements InputStub {
     private ClipboardManager clipboard;
     private long lastClipboardTimestamp = System.currentTimeMillis();
     private boolean keyboardVisible = false;
+    private long mNativeContext;
     private static boolean clipboardSyncEnabled = false;
     private static boolean hardwareKbdScancodesWorkaround = false;
     private final InputMethodManager mIMM = (InputMethodManager)getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -282,7 +283,7 @@ public class LorieView extends SurfaceView implements InputStub {
         @Override public void surfaceCreated(@NonNull SurfaceHolder holder) {}
 
         @Override public void surfaceChanged(@NonNull SurfaceHolder holder, int f, int width, int height) {
-            LorieView.this.surfaceChanged(holder.getSurface());
+            LorieView.this.surfaceChanged(mNativeContext, holder.getSurface());
             width = getMeasuredWidth();
             height = getMeasuredHeight();
 
@@ -291,7 +292,7 @@ public class LorieView extends SurfaceView implements InputStub {
         }
 
         @Override public void surfaceDestroyed(@NonNull SurfaceHolder holder) {
-            LorieView.this.surfaceChanged(null);
+            LorieView.this.surfaceChanged(mNativeContext, null);
         }
     };
 
@@ -304,7 +305,7 @@ public class LorieView extends SurfaceView implements InputStub {
     private void init() {
         getHolder().addCallback(mSurfaceCallback);
         clipboard = (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
-        nativeInit();
+        mNativeContext = nativeInit();
 
         setFocusable(true);
         setFocusableInTouchMode(true);
@@ -317,6 +318,13 @@ public class LorieView extends SurfaceView implements InputStub {
                 return true;
             }
         });
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        nativeDestroy(mNativeContext);
+        mNativeContext = 0;
     }
 
     public void setCallback(Callback callback) {
@@ -416,7 +424,7 @@ public class LorieView extends SurfaceView implements InputStub {
         else
             name = "external";
 
-        sendWindowChange(p.x, p.y, framerate, name);
+        sendWindowChange(mNativeContext, p.x, p.y, framerate, name);
     }
 
     @Keep
@@ -511,7 +519,7 @@ public class LorieView extends SurfaceView implements InputStub {
             inputSourceWidth = p.x;
             inputSourceHeight = p.y;
         }
-        setViewport(viewport.left, viewport.top, viewport.width(), viewport.height(), p.x, p.y, hiddenBottom);
+        setViewport(mNativeContext, viewport.left, viewport.top, viewport.width(), viewport.height(), p.x, p.y, hiddenBottom);
 
         updateInputTransform();
         if (!dimensionsFrozen)
@@ -577,10 +585,10 @@ public class LorieView extends SurfaceView implements InputStub {
 
     public void reloadPreferences(Prefs p) {
         String filtering = p.displayFilteringMode.get();
-        setFiltering("nearest".equals(filtering) ? GLES20.GL_NEAREST : GLES20.GL_LINEAR);
+        setFiltering(mNativeContext, "nearest".equals(filtering) ? GLES20.GL_NEAREST : GLES20.GL_LINEAR);
         hardwareKbdScancodesWorkaround = p.hardwareKbdScancodesWorkaround.get();
         clipboardSyncEnabled = p.clipboardEnable.get();
-        setClipboardSyncEnabled(clipboardSyncEnabled, clipboardSyncEnabled);
+        setClipboardSyncEnabled(mNativeContext, clipboardSyncEnabled, clipboardSyncEnabled);
         TouchInputHandler.refreshInputDevices();
     }
 
@@ -603,7 +611,7 @@ public class LorieView extends SurfaceView implements InputStub {
 
         // A requesting X11 client blocks on a SelectionNotify, so this must always answer, even
         // with an empty string, or the request is left unresolved.
-        sendClipboardEvent(text.getBytes(UTF_8));
+        sendClipboardEvent(mNativeContext, text.getBytes(UTF_8));
         if (!text.isEmpty())
             Log.d("CLIP", "sending clipboard contents: " + text);
     }
@@ -622,7 +630,7 @@ public class LorieView extends SurfaceView implements InputStub {
                 (desc.hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN) ||
                         desc.hasMimeType(ClipDescription.MIMETYPE_TEXT_HTML))) {
             lastClipboardTimestamp = timestamp;
-            sendClipboardAnnounce();
+            sendClipboardAnnounce(mNativeContext);
             Log.d("CLIP", "sending clipboard announce");
         }
     }
@@ -675,43 +683,67 @@ public class LorieView extends SurfaceView implements InputStub {
         }, 10);
     }
 
-    @FastNative private native void nativeInit();
-    @FastNative private native void surfaceChanged(Surface surface);
-    @FastNative private native void setFiltering(int filtering);
-    @FastNative static native void connect(int fd);
-    @CriticalNative static native boolean connected();
-    @FastNative static native void startLogcat(int fd);
-    @FastNative static native void setClipboardSyncEnabled(boolean enabled, boolean ignored);
-    @FastNative public native void sendClipboardAnnounce();
-    @FastNative public native void sendClipboardEvent(byte[] text);
-    @FastNative static native void sendWindowChange(int width, int height, int framerate, String name);
-    @FastNative static native void setViewport(int x, int y, int width, int height, int expectedWidth, int expectedHeight, int hiddenBottom);
-    @FastNative private static native void setRendererZoom(int percent);
+    @FastNative private native long nativeInit();
+    @FastNative private native void nativeDestroy(long ptr);
+    @FastNative private native void surfaceChanged(long ptr, Surface surface);
+    @FastNative private native void setFiltering(long ptr, int filtering);
+    @FastNative private native void setClipboardSyncEnabled(long ptr, boolean enabled, boolean ignored);
+    @FastNative private native void sendClipboardAnnounce(long ptr);
+    @FastNative private native void sendClipboardEvent(long ptr, byte[] text);
+    @FastNative private native void sendWindowChange(long ptr, int width, int height, int framerate, String name);
+    @FastNative private native void setViewport(long ptr, int x, int y, int width, int height, int expectedWidth, int expectedHeight, int hiddenBottom);
+    @FastNative private native void setRendererZoom(long ptr, int percent);
+
+    // Public API stays free of the native pointer; it's threaded through to an overload below.
+    public void connect(int fd) { connect(mNativeContext, fd); }
+    @FastNative private static native void connect(long ptr, int fd);
+
+    public boolean connected() { return connected(mNativeContext); }
+    @CriticalNative private static native boolean connected(long ptr);
+
+    public void startLogcat(int fd) { startLogcat(mNativeContext, fd); }
+    @FastNative private static native void startLogcat(long ptr, int fd);
 
     public void adjustRendererZoom(int delta) {
         rendererZoom = MathUtils.clamp(rendererZoom + delta, 100, 400);
-        setRendererZoom(rendererZoom);
+        setRendererZoom(mNativeContext, rendererZoom);
     }
 
     public void resetRendererZoom() {
         rendererZoom = 100;
-        setRendererZoom(rendererZoom);
+        setRendererZoom(mNativeContext, rendererZoom);
     }
 
     public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode) {
         freezeDimensions(isInPictureInPictureMode);
         // Zooming a floating window makes no sense, but the zoom is restored along with the size.
-        setRendererZoom(isInPictureInPictureMode ? 100 : rendererZoom);
+        setRendererZoom(mNativeContext, isInPictureInPictureMode ? 100 : rendererZoom);
     }
 
-    @FastNative public native void sendMouseEvent(float x, float y, int whichButton, boolean buttonDown, boolean relative);
-    @FastNative public native void sendTouchEvent(int action, int id, int x, int y);
-    @FastNative public native void sendStylusEvent(float x, float y, int pressure, int tiltX, int tiltY, int orientation, int buttons, boolean eraser, boolean mouseMode);
-    @FastNative static public native void requestStylusEnabled(boolean enabled);
-    @FastNative public native void sendLockKeysState(int state);
-    @FastNative public native boolean sendKeyEvent(int scanCode, int keyCode, boolean keyDown);
-    @FastNative public native void sendTextEvent(byte[] text);
-    @CriticalNative public static native boolean requestConnection();
+    public void sendMouseEvent(float x, float y, int whichButton, boolean buttonDown, boolean relative) { sendMouseEvent(mNativeContext, x, y, whichButton, buttonDown, relative); }
+    @FastNative private native void sendMouseEvent(long ptr, float x, float y, int whichButton, boolean buttonDown, boolean relative);
+
+    public void sendTouchEvent(int action, int id, int x, int y) { sendTouchEvent(mNativeContext, action, id, x, y); }
+    @FastNative private native void sendTouchEvent(long ptr, int action, int id, int x, int y);
+
+    public void sendStylusEvent(float x, float y, int pressure, int tiltX, int tiltY, int orientation, int buttons, boolean eraser, boolean mouseMode) { sendStylusEvent(mNativeContext, x, y, pressure, tiltX, tiltY, orientation, buttons, eraser, mouseMode); }
+    @FastNative private native void sendStylusEvent(long ptr, float x, float y, int pressure, int tiltX, int tiltY, int orientation, int buttons, boolean eraser, boolean mouseMode);
+
+    public void requestStylusEnabled(boolean enabled) { requestStylusEnabled(mNativeContext, enabled); }
+    @FastNative private native void requestStylusEnabled(long ptr, boolean enabled);
+
+    public void sendLockKeysState(int state) { sendLockKeysState(mNativeContext, state); }
+    @FastNative private native void sendLockKeysState(long ptr, int state);
+
+    public boolean sendKeyEvent(int scanCode, int keyCode, boolean keyDown) { return sendKeyEvent(mNativeContext, scanCode, keyCode, keyDown); }
+    @FastNative private native boolean sendKeyEvent(long ptr, int scanCode, int keyCode, boolean keyDown);
+
+    public void sendTextEvent(byte[] text) { sendTextEvent(mNativeContext, text); }
+    @FastNative private native void sendTextEvent(long ptr, byte[] text);
+
+    public boolean requestConnection() { return requestConnection(mNativeContext); }
+    @CriticalNative private static native boolean requestConnection(long ptr);
+
     @CriticalNative public static native long getLastInputTimestamp();
     @CriticalNative public static native void markUserActivity();
 

--- a/lorie/src/main/java/com/termux/x11/MainActivity.java
+++ b/lorie/src/main/java/com/termux/x11/MainActivity.java
@@ -150,7 +150,7 @@ public class MainActivity extends AppCompatActivity {
     ViewTreeObserver.OnPreDrawListener mOnPredrawListener = new ViewTreeObserver.OnPreDrawListener() {
         @Override
         public boolean onPreDraw() {
-            if (!LorieView.connected())
+            if (!getLorieView().connected())
                 return false;
 
             finishStartupDraw();
@@ -306,7 +306,7 @@ public class MainActivity extends AppCompatActivity {
     @SuppressLint("ClickableViewAccessibility")
     private void initStylusAuxButtons() {
         final ViewPager pager = getTerminalToolbarViewPager();
-        boolean stylusMenuEnabled = prefs.showStylusClickOverride.get() && LorieView.connected();
+        boolean stylusMenuEnabled = prefs.showStylusClickOverride.get() && getLorieView().connected();
         final float menuUnselectedTrasparency = 0.66f;
         final float menuSelectedTrasparency = 1.0f;
         Button left = findViewById(R.id.button_left_click);
@@ -398,7 +398,7 @@ public class MainActivity extends AppCompatActivity {
 
     private void showStylusAuxButtons(boolean show) {
         LinearLayout buttons = findViewById(R.id.mouse_helper_visibility);
-        if (LorieView.connected() && show) {
+        if (getLorieView().connected() && show) {
             buttons.setVisibility(View.VISIBLE);
             buttons.setAlpha(isInPictureInPictureMode ? 0.f : 1.f);
         } else {
@@ -453,7 +453,7 @@ public class MainActivity extends AppCompatActivity {
 
     private void showMouseAuxButtons(boolean show) {
         View v = findViewById(R.id.mouse_buttons);
-        v.setVisibility((LorieView.connected() && show && "1".equals(prefs.touchMode.get())) ? View.VISIBLE : View.GONE);
+        v.setVisibility((getLorieView().connected() && show && "1".equals(prefs.touchMode.get())) ? View.VISIBLE : View.GONE);
         v.setAlpha(isInPictureInPictureMode ? 0.f : 0.7f);
         makeSureHelpersAreVisibleAndInScreenBounds();
     }
@@ -574,7 +574,7 @@ public class MainActivity extends AppCompatActivity {
                 service = null;
 
                 Log.v("Lorie", "Disconnected");
-                runOnUiThread(() -> { LorieView.connect(-1); clientConnectedStateChanged();} );
+                runOnUiThread(() -> { getLorieView().connect(-1); clientConnectedStateChanged();} );
             }, 0);
         } catch (RemoteException ignored) {}
 
@@ -583,7 +583,7 @@ public class MainActivity extends AppCompatActivity {
                 Log.v("LorieBroadcastReceiver", "Extracting logcat fd.");
                 ParcelFileDescriptor logcatOutput = service.getLogcatOutput();
                 if (logcatOutput != null)
-                    LorieView.startLogcat(logcatOutput.detachFd());
+                    getLorieView().startLogcat(logcatOutput.detachFd());
 
                 tryConnect();
 
@@ -596,11 +596,11 @@ public class MainActivity extends AppCompatActivity {
     }
 
     boolean tryConnect() {
-        if (LorieView.connected())
+        if (getLorieView().connected())
             return false;
 
         if (service == null) {
-            boolean sent = LorieView.requestConnection();
+            boolean sent = getLorieView().requestConnection();
             handler.postDelayed(this::tryConnect, 250);
             return true;
         }
@@ -609,7 +609,7 @@ public class MainActivity extends AppCompatActivity {
             ParcelFileDescriptor fd = service.getXConnection();
             if (fd != null) {
                 Log.v("MainActivity", "Extracting X connection socket.");
-                LorieView.connect(fd.detachFd());
+                getLorieView().connect(fd.detachFd());
                 finishStartupDraw();
                 getLorieView().triggerCallback();
                 clientConnectedStateChanged();
@@ -664,7 +664,7 @@ public class MainActivity extends AppCompatActivity {
         useTermuxEKBarBehaviour = prefs.useTermuxEKBarBehaviour.get();
         showIMEWhileExternalConnected = prefs.showIMEWhileExternalConnected.get();
 
-        findViewById(R.id.mouse_buttons).setVisibility(prefs.showMouseHelper.get() && "1".equals(prefs.touchMode.get()) && LorieView.connected() ? View.VISIBLE : View.GONE);
+        findViewById(R.id.mouse_buttons).setVisibility(prefs.showMouseHelper.get() && "1".equals(prefs.touchMode.get()) && getLorieView().connected() ? View.VISIBLE : View.GONE);
         showMouseAuxButtons(prefs.showMouseHelper.get());
         showStylusAuxButtons(prefs.showStylusClickOverride.get());
 
@@ -720,7 +720,7 @@ public class MainActivity extends AppCompatActivity {
         final ViewPager pager = getTerminalToolbarViewPager();
         ViewGroup parent = (ViewGroup) pager.getParent();
 
-        boolean showNow = !isInPictureInPictureMode && LorieView.connected() && prefs.showAdditionalKbd.get() && prefs.additionalKbdVisible.get();
+        boolean showNow = !isInPictureInPictureMode && getLorieView().connected() && prefs.showAdditionalKbd.get() && prefs.additionalKbdVisible.get();
 
         pager.setVisibility(showNow ? View.VISIBLE : View.INVISIBLE);
 
@@ -835,7 +835,7 @@ public class MainActivity extends AppCompatActivity {
     public void toggleExtraKeys(boolean visible, boolean saveState) {
         boolean enabled = prefs.showAdditionalKbd.get();
 
-        if (enabled && LorieView.connected() && saveState)
+        if (enabled && getLorieView().connected() && saveState)
             prefs.additionalKbdVisible.put(visible);
 
         setTerminalToolbarView();
@@ -968,7 +968,7 @@ public class MainActivity extends AppCompatActivity {
     /** Syncs screenIdleTimeout state/timer to the current preference without extending an already-scheduled check. */
     private void applyScreenIdleTimeout() {
         String mode = prefs.screenIdleTimeout.get();
-        boolean connected = LorieView.connected();
+        boolean connected = getLorieView().connected();
         if (!connected || "never".equals(mode) || "system".equals(mode)) {
             handler.removeCallbacks(screenIdleTimeoutCheck);
             screenIdleTimeoutArmedMode = null;
@@ -1064,7 +1064,7 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     public void onUserLeaveHint() {
-        if (!prefs.PIP.get() || !hasPipPermission(this) || !LorieView.connected())
+        if (!prefs.PIP.get() || !hasPipPermission(this) || !getLorieView().connected())
             return;
 
         PictureInPictureParams.Builder params = new PictureInPictureParams.Builder();
@@ -1113,7 +1113,7 @@ public class MainActivity extends AppCompatActivity {
     @SuppressWarnings("SameParameterValue")
     void clientConnectedStateChanged() {
         runOnUiThread(()-> {
-            boolean connected = LorieView.connected();
+            boolean connected = getLorieView().connected();
 
             // A picture-in-picture window has nothing to show without a client, and there is no way
             // back to the normal size from it, so the window is closed.
@@ -1141,7 +1141,7 @@ public class MainActivity extends AppCompatActivity {
         if (getInstance() == null)
             return false;
 
-        return LorieView.connected();
+        return getInstance().getLorieView().connected();
     }
 
     public static void getRealMetrics(DisplayMetrics m) {

--- a/lorie/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/lorie/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -261,7 +261,7 @@ public class TouchInputHandler {
                 });
         android.util.Log.d("DEVICES", "requesting stylus " + stylusAvailable.get());
         android.util.Log.d("DEVICES", "external keyboard connected " + externalKeyboardAvailable.get());
-        LorieView.requestStylusEnabled(stylusAvailable.get());
+        MainActivity.getInstance().getLorieView().requestStylusEnabled(stylusAvailable.get());
         MainActivity.getInstance().setExternalKeyboardConnected(externalKeyboardAvailable.get());
     }
 


### PR DESCRIPTION
Native GUI-side state (renderer, connection fd, JNI refs) is bundled into a single LorieViewResources object, heap-allocated in LorieView's constructor and freed in onDetachedFromWindow, instead of living forever in scattered process globals. The renderer's background thread, EGL context, and GL resources are torn down and joined before the object is freed.

Every native call now takes an explicit pointer to its own instance instead of implicitly reaching a shared global, so each LorieView addresses its own native state. Callers outside LorieView keep their existing method names and signatures; the pointer is threaded through internally.

A step towards supporting multiple LorieView/MainActivity instances side by side (multi-window).