### PR TITLE
feat(app): add xstartupCommand preference for CmdEntryPoint's X session

### DIFF
--- a/lorie/src/main/aidl/com/termux/x11/ICmdEntryInterface.aidl
+++ b/lorie/src/main/aidl/com/termux/x11/ICmdEntryInterface.aidl
@@ -1,7 +1,10 @@
 package com.termux.x11;
 
+import android.os.Bundle;
+
 // This interface is used by utility on termux side.
 interface ICmdEntryInterface {
     ParcelFileDescriptor getXConnection();
     ParcelFileDescriptor getLogcatOutput();
+    oneway void setPreferences(in Bundle prefs);
 }

--- a/lorie/src/main/cpp/lorie/InitOutput.c
+++ b/lorie/src/main/cpp/lorie/InitOutput.c
@@ -99,6 +99,12 @@ static lorieScreenInfo lorieScreen = {
 }, *pvfb = &lorieScreen;
 static char *xstartup = NULL;
 static char **xstartupArgv = NULL;
+static char *xstartupPreference = NULL; // Set over JNI, lower priority than -xstartup/-- on the command line.
+
+void lorieSetXstartupPreference(const char *cmd) {
+    free(xstartupPreference);
+    xstartupPreference = cmd && *cmd ? strdup(cmd) : NULL;
+}
 
 // Owned by the activity process, handed to us over the connection socket. Points at a placeholder until
 // the first connection so callers don't need a NULL check.
@@ -289,6 +295,8 @@ void ddxReady(void) {
     if (!xstartupArgv) {
         if (xstartup && !strlen(xstartup)) // allow overriding $TERMUX_X11_XSTARTUP with empty xstartup arg
             return;
+        if (!xstartup || !strlen(xstartup))
+            xstartup = xstartupPreference;
         if (!xstartup || !strlen(xstartup))
             xstartup = getenv("TERMUX_X11_XSTARTUP");
         if (!xstartup || !strlen(xstartup))

--- a/lorie/src/main/cpp/lorie/cmdentrypoint.cpp
+++ b/lorie/src/main/cpp/lorie/cmdentrypoint.cpp
@@ -47,9 +47,14 @@ char *xtrans_unix_dir_x11 = nullptr;
 struct xorg_list registeredBuffers;
 
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_termux_x11_CmdEntryPoint_start(JNIEnv *env, __unused jclass cls, jobjectArray args) {
+Java_com_termux_x11_CmdEntryPoint_start(JNIEnv *env, __unused jclass cls, jobjectArray args, jstring xstartupCommand) {
     pthread_t t;
     JavaVM* vm = nullptr;
+
+    const char *xstartupCommandChars = env->GetStringUTFChars(xstartupCommand, JNI_FALSE);
+    lorieSetXstartupPreference(xstartupCommandChars);
+    env->ReleaseStringUTFChars(xstartupCommand, xstartupCommandChars);
+
     auto detectTracer = []() -> Bool {
         FILE *fp;
         char line[256];

--- a/lorie/src/main/cpp/lorie/lorie.h
+++ b/lorie/src/main/cpp/lorie/lorie.h
@@ -25,6 +25,7 @@ extern "C" {
 struct lorie_shared_server_state;
 
 void lorieConfigureNotify(int width, int height, int framerate, size_t name_size, char* name);
+void lorieSetXstartupPreference(const char* cmd);
 void lorieEnableClipboardSync(Bool enable);
 void lorieSendClipboardData(const char* data);
 void lorieInitClipboard(void);

--- a/lorie/src/main/java/com/termux/x11/CmdEntryPoint.java
+++ b/lorie/src/main/java/com/termux/x11/CmdEntryPoint.java
@@ -9,7 +9,6 @@ import android.content.Context;
 import android.content.IIntentReceiver;
 import android.content.IIntentSender;
 import android.content.Intent;
-import android.os.Binder;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -18,13 +17,20 @@ import android.os.Looper;
 import android.os.ParcelFileDescriptor;
 import android.os.RemoteException;
 import android.util.Log;
+import android.util.Xml;
 import android.view.Surface;
 
 import androidx.annotation.Keep;
 
+import org.xmlpull.v1.XmlPullParser;
+
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 @Keep @SuppressLint({"StaticFieldLeak", "UnsafeDynamicallyLoadedCode"})
 public class CmdEntryPoint extends ICmdEntryInterface.Stub {
@@ -32,6 +38,9 @@ public class CmdEntryPoint extends ICmdEntryInterface.Stub {
     static final Handler handler;
     public static Context ctx;
     private final Intent intent = createIntent();
+    private final Map<String, String> filePreferences = readFilePreferences(); // Own shared_prefs read once at startup; empty if unreadable (standalone flavor, different UID).
+    private final Object preferencesLock = new Object();
+    private Bundle receivedPreferences;
 
     /**
      * Command-line entry point.
@@ -45,11 +54,77 @@ public class CmdEntryPoint extends ICmdEntryInterface.Stub {
     }
 
     CmdEntryPoint(String[] args) {
-        if (!start(args))
+        if (!start(args, fetchPreference("xstartupCommand", "")))
             System.exit(1);
 
         spawnListeningThread();
         sendBroadcastDelayed();
+    }
+
+    private static Map<String, String> readFilePreferences() {
+        Map<String, String> result = new HashMap<>();
+        if (ctx == null)
+            return result;
+        try {
+            String dataDir = ctx.getPackageManager().getApplicationInfo(BuildConfig.APPLICATION_ID, 0).dataDir;
+            File file = new File(dataDir, "shared_prefs/" + BuildConfig.APPLICATION_ID + "_preferences.xml");
+            if (!file.exists())
+                return result;
+
+            try (FileInputStream in = new FileInputStream(file)) {
+                XmlPullParser parser = Xml.newPullParser();
+                parser.setInput(in, null);
+                for (int event = parser.getEventType(); event != XmlPullParser.END_DOCUMENT; event = parser.next()) {
+                    if (event != XmlPullParser.START_TAG)
+                        continue;
+                    String name = parser.getAttributeValue(null, "name");
+                    String value = parser.getAttributeValue(null, "value");
+                    if (name != null && value != null)
+                        result.put(name, value);
+                }
+            }
+        } catch (Exception e) {
+            // Different UID (standalone flavor) -- can't read the app's private files.
+        }
+        return result;
+    }
+
+    @Override
+    public void setPreferences(Bundle prefs) {
+        synchronized (preferencesLock) {
+            receivedPreferences = prefs;
+            preferencesLock.notifyAll();
+        }
+    }
+
+    // defaultValue's type (Integer/Boolean/String) picks how the raw stored string gets parsed.
+    @SuppressWarnings("unchecked")
+    private <T> T fetchPreference(String key, T defaultValue) {
+        String raw = filePreferences.get(key);
+        if (raw == null) {
+            // Ask the app instead, sending the ACTION_START intent early instead of only from
+            // sendBroadcastDelayed() afterward; setPreferences() below wakes this up.
+            synchronized (preferencesLock) {
+                if (receivedPreferences == null) {
+                    sendBroadcast(intent);
+                    try {
+                        preferencesLock.wait(2000);
+                    } catch (InterruptedException ignored) {}
+                }
+                raw = receivedPreferences != null ? receivedPreferences.getString(key) : null;
+            }
+        }
+        if (raw == null)
+            return defaultValue;
+        try {
+            if (defaultValue instanceof Integer)
+                return (T) Integer.valueOf(raw);
+            if (defaultValue instanceof Boolean)
+                return (T) Boolean.valueOf(raw);
+            return (T) raw;
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
     }
 
     @SuppressLint({"WrongConstant", "PrivateApi"})
@@ -62,9 +137,10 @@ public class CmdEntryPoint extends ICmdEntryInterface.Stub {
         Intent intent = new Intent(ACTION_START);
         intent.putExtra(null, bundle);
         intent.setPackage(BuildConfig.APPLICATION_ID);
+        intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES); // Broadcasts are dropped for force-stopped apps unless explicitly told otherwise.
 
         if (getuid() == 0 || getuid() == 2000)
-            intent.setFlags(0x00400000 /* FLAG_RECEIVER_FROM_SHELL */);
+            intent.addFlags(0x00400000 /* FLAG_RECEIVER_FROM_SHELL */);
 
         return intent;
     }
@@ -163,7 +239,7 @@ public class CmdEntryPoint extends ICmdEntryInterface.Stub {
         return context;
     }
 
-    public static native boolean start(String[] args);
+    public static native boolean start(String[] args, String xstartupCommand);
     public native ParcelFileDescriptor getXConnection();
     public native ParcelFileDescriptor getLogcatOutput();
     private static native boolean connected();

--- a/lorie/src/main/java/com/termux/x11/LorieBroadcastReceiver.java
+++ b/lorie/src/main/java/com/termux/x11/LorieBroadcastReceiver.java
@@ -3,15 +3,47 @@ package com.termux.x11;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.RemoteException;
 import android.util.Log;
 
 public class LorieBroadcastReceiver extends BroadcastReceiver {
+    private static Prefs prefs; // reused across requests when no Activity is bound
+
     @Override
     public void onReceive(Context context, Intent intent) {
+        if (CmdEntryPoint.ACTION_START.equals(intent.getAction()))
+            sendPreferences(context, intent);
+
         MainActivity activity = MainActivity.getInstance();
         if (activity != null)
             activity.onBroadcastReceive(context, intent);
         else
             Log.w("LorieBroadcastReceiver", "Got " + intent.getAction() + " but no MainActivity instance in this process");
+    }
+
+    // Replies over the binder the ACTION_START intent already carries, Activity or not.
+    private void sendPreferences(Context context, Intent intent) {
+        Bundle bundle = intent.getBundleExtra(null);
+        IBinder ibinder = bundle != null ? bundle.getBinder(null) : null;
+        ICmdEntryInterface remote = ibinder != null ? ICmdEntryInterface.Stub.asInterface(ibinder) : null;
+        if (remote == null)
+            return;
+
+        Prefs p = MainActivity.getInstance() != null ? MainActivity.getPrefs() : prefs(context);
+        Bundle response = new Bundle();
+        response.putString("xstartupCommand", p.xstartupCommand.get());
+        try {
+            remote.setPreferences(response);
+        } catch (RemoteException e) {
+            Log.e("LorieBroadcastReceiver", "Failed to send preferences", e);
+        }
+    }
+
+    private static synchronized Prefs prefs(Context context) {
+        if (prefs == null)
+            prefs = new Prefs(context);
+        return prefs;
     }
 }

--- a/lorie/src/main/java/com/termux/x11/LoriePreferences.java
+++ b/lorie/src/main/java/com/termux/x11/LoriePreferences.java
@@ -644,6 +644,10 @@ public class LoriePreferences extends AppCompatActivity implements PreferenceFra
                                 edit.putString(key, newValue);
                                 break;
                             }
+                            case "xstartupCommand": {
+                                sendResponse(remote, 1, 1, "xstartupCommand: can only be changed from the app's own settings screen.");
+                                return;
+                            }
                             default: {
                                 PrefsProto.Preference pref = p.keys.get(key);
                                 if (pref != null && pref.type == boolean.class) {

--- a/lorie/src/main/res/values/strings.xml
+++ b/lorie/src/main/res/values/strings.xml
@@ -93,6 +93,8 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="lorie_pref_enforceCharBasedInput">Enforce char based input</string>
     <string name="lorie_pref_enforceCharBasedInput_summary">Suppresses suggestions, predictive typing and CJK languages</string>
 
+    <string name="lorie_pref_xstartupCommand">X startup command</string>
+    <string name="lorie_pref_xstartupCommand_summary">Run this command after the X server starts, when the session was not started with -xstartup or -- on the command line.</string>
     <string name="lorie_pref_clipboardEnable">Clipboard sharing</string>
     <string name="lorie_pref_requestNotificationPermission">Request notification permission</string>
     <string name="lorie_pref_xrMode">Meta Oculus XR mode</string>

--- a/lorie/src/main/res/xml/preferences.xml
+++ b/lorie/src/main/res/xml/preferences.xml
@@ -54,6 +54,7 @@
         <SwitchPreferenceCompat app:key="enforceCharBasedInput" app:defaultValue="false" />
     </PreferenceScreen>
     <PreferenceScreen app:key="other">
+        <EditTextPreference app:key="xstartupCommand" app:defaultValue="" android:summary="@string/lorie_pref_xstartupCommand_summary" />
         <SwitchPreferenceCompat app:key="clipboardEnable" app:defaultValue="true" />
         <Preference app:key="requestNotificationPermission" />
         <Preference app:key="configureResponseToUserActions" app:fragment="userActions" />


### PR DESCRIPTION
Lets a CLI-launched termux-x11 session pick up a command configured in the app's settings, at lower priority than -xstartup/-- and higher than $TERMUX_X11_XSTARTUP. Passed to the native start() call over JNI; not settable via termux-x11-preference, only from the app's own settings screen.

CmdEntryPoint now reads its own shared_prefs file directly when possible, falling back to a broadcast round-trip (reusing the existing ACTION_START intent's binder) when running under a different UID.

Fixes #664.