### PR TITLE
feat(present): implement DDXRingBell as a haptic/audible bell

### DIFF
--- a/lorie/src/main/AndroidManifest.xml
+++ b/lorie/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.VIBRATE"/>
 
     <application
         android:allowBackup="false"

--- a/lorie/src/main/cpp/lorie/InitInput.c
+++ b/lorie/src/main/cpp/lorie/InitInput.c
@@ -48,9 +48,6 @@ ProcessInputEvents(void) {
     mieqProcessInputEvents();
 }
 
-void
-DDXRingBell(__unused int volume, __unused int pitch, __unused int duration) {}
-
 static int
 lorieKeybdProc(DeviceIntPtr pDevice, int onoff) {
     DevicePtr pDev = (DevicePtr) pDevice;

--- a/lorie/src/main/cpp/lorie/activity.cpp
+++ b/lorie/src/main/cpp/lorie/activity.cpp
@@ -38,7 +38,7 @@ static int64_t nowMs() {
 
 static struct {
     jclass self;
-    jmethodID clientConnectedStateChanged, resetIme;
+    jmethodID clientConnectedStateChanged, resetIme, ringBell;
 } MainActivity = {nullptr};
 
 static struct {
@@ -144,6 +144,7 @@ static jlong nativeInit(JNIEnv *env, jobject thiz) {
         MainActivity.self = FindClassOrDie(env,  "com/termux/x11/MainActivity");
         MainActivity.clientConnectedStateChanged = FindMethodOrDie(env, MainActivity.self, "clientConnectedStateChanged", "()V", JNI_FALSE);
         MainActivity.resetIme = FindMethodOrDie(env, env->GetObjectClass(thiz), "resetIme", "()V", JNI_FALSE);
+        MainActivity.ringBell = FindMethodOrDie(env, env->GetObjectClass(thiz), "ringBell", "()V", JNI_FALSE);
     }
 
     return (jlong) (intptr_t) new (malloc(sizeof(LorieViewResources))) LorieViewResources(env, thiz);
@@ -269,6 +270,10 @@ int LorieViewResources::xcallback(int fd, int events) {
                 case EVENT_SYNC_REPLY: {
                     jmethodID id = env->GetMethodID(env->GetObjectClass(thiz), "onSyncReply", "(I)V");
                     env->CallVoidMethod(thiz, id, (jint) e.sync.serial);
+                    break;
+                }
+                case EVENT_RING_BELL: {
+                    env->CallVoidMethod(thiz, MainActivity.ringBell);
                     break;
                 }
             }

--- a/lorie/src/main/cpp/lorie/cmdentrypoint.cpp
+++ b/lorie/src/main/cpp/lorie/cmdentrypoint.cpp
@@ -483,6 +483,13 @@ void lorieRequestClipboard(void) {
     }
 }
 
+extern "C" void DDXRingBell(int volume, __unused int pitch, __unused int duration) {
+    if (volume && conn_fd != -1) {
+        lorieEvent e = { .type = EVENT_RING_BELL };
+        write(conn_fd, &e, sizeof(e));
+    }
+}
+
 bool lorieConnectionAlive(void) {
     if (conn_fd == -1)
         return false;

--- a/lorie/src/main/cpp/lorie/lorie.h
+++ b/lorie/src/main/cpp/lorie/lorie.h
@@ -114,6 +114,7 @@ typedef enum {
     EVENT_LOCK_KEYS_STATE,
     EVENT_SYNC,
     EVENT_SYNC_REPLY,
+    EVENT_RING_BELL,
 } eventType;
 
 typedef union {

--- a/lorie/src/main/java/com/termux/x11/LorieView.java
+++ b/lorie/src/main/java/com/termux/x11/LorieView.java
@@ -12,11 +12,18 @@ import android.graphics.PointF;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.ColorDrawable;
+import android.media.AudioAttributes;
+import android.media.AudioManager;
+import android.media.ToneGenerator;
 import android.opengl.GLES20;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+import android.os.VibrationAttributes;
+import android.os.VibrationEffect;
+import android.os.Vibrator;
+import android.os.VibratorManager;
 import android.text.Editable;
 import android.text.InputType;
 import android.util.AttributeSet;
@@ -683,6 +690,47 @@ public class LorieView extends SurfaceView implements InputStub {
             else
                 mIMM.restartInput(this);
         }, 10);
+    }
+
+    /**
+     * X11 bell (XBell/XKB), forwarded from the X server over the native connection.
+     * It is called from native code, not from Java.
+     * @noinspection unused
+     */
+    @Keep void ringBell() {
+        try {
+            Vibrator vibrator = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                    ? ((VibratorManager) getContext().getSystemService(Context.VIBRATOR_MANAGER_SERVICE)).getDefaultVibrator()
+                    : (Vibrator) getContext().getSystemService(Context.VIBRATOR_SERVICE);
+            if (vibrator != null && vibrator.hasVibrator()) {
+                // Two short pulses, so it does not read as a single IME key-tap haptic.
+                long[] pattern = { 0, 80, 60, 80 };
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    vibrator.vibrate(VibrationEffect.createWaveform(pattern, -1),
+                            new VibrationAttributes.Builder().setUsage(VibrationAttributes.USAGE_NOTIFICATION).build());
+                } else {
+                    AudioAttributes attributes = new AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_NOTIFICATION_EVENT)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                            .build();
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+                        vibrator.vibrate(VibrationEffect.createWaveform(pattern, -1), attributes);
+                    else
+                        vibrator.vibrate(pattern, -1, attributes);
+                }
+                return;
+            }
+        } catch (RuntimeException e) {
+            Log.w("LorieView", "Failed to vibrate for bell", e);
+        }
+
+        try {
+            ToneGenerator tone = new ToneGenerator(AudioManager.STREAM_NOTIFICATION, ToneGenerator.MAX_VOLUME);
+            tone.startTone(ToneGenerator.TONE_PROP_BEEP, 150);
+            postDelayed(tone::release, 200);
+        } catch (RuntimeException e) {
+            Log.w("LorieView", "Failed to play bell tone", e);
+        }
     }
 
     @FastNative private native long nativeInit();


### PR DESCRIPTION
Forwards X11 bell requests (XBell/XkbBell) over the existing cross-process connection to the renderer, which vibrates (two short pulses, distinct from IME key-tap haptics) or, if no vibrator is present, plays a short tone.

Test with command `printf '\a'` in aterm since xfce terminal defaults to disable audible bell.