### PR TITLE
fix(app): force Prefs onto our own package's SharedPreferences

### DIFF
--- a/lorie/src/main/java/com/termux/x11/LoriePreferences.java
+++ b/lorie/src/main/java/com/termux/x11/LoriePreferences.java
@@ -15,6 +15,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.database.ContentObserver;
@@ -916,8 +917,19 @@ public class LoriePreferences extends AppCompatActivity implements PreferenceFra
         private PrefsProto() {} // No instantiation allowed
         protected PrefsProto(Context ctx) {
             this.ctx = ctx;
-            builtInDisplayPreferences = PreferenceManager.getDefaultSharedPreferences(ctx);
-            secondaryDisplayPreferences = ctx.getSharedPreferences("secondary", Context.MODE_PRIVATE);
+
+            // A platform-supplied Context can identify as the host app's package in sharedUid builds.
+            Context prefsCtx = ctx;
+            if (!BuildConfig.APPLICATION_ID.equals(ctx.getPackageName())) {
+                try {
+                    prefsCtx = ctx.createPackageContext(BuildConfig.APPLICATION_ID, 0);
+                } catch (PackageManager.NameNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            builtInDisplayPreferences = PreferenceManager.getDefaultSharedPreferences(prefsCtx);
+            secondaryDisplayPreferences = prefsCtx.getSharedPreferences("secondary", Context.MODE_PRIVATE);
             recheckStoringSecondaryDisplayPreferences();
         }
 


### PR DESCRIPTION
In sharedUid builds a Context handed to us by the platform (e.g. a BroadcastReceiver's onReceive when no com.termux.x11 process is running yet) can identify as the host app's package instead of our own, so PrefsProto silently read/wrote the wrong app's shared_prefs file. termux-x11-preference would report success and even echo the new value back via `list`, but the running app never saw the change.