### PR TITLE
feat(lorie): add pinch-to-zoom with combined pan

### DIFF
--- a/lorie/src/main/cpp/lorie/activity.cpp
+++ b/lorie/src/main/cpp/lorie/activity.cpp
@@ -254,6 +254,12 @@ int LorieViewResources::xcallback(int fd, int events) {
                 }
                 case EVENT_WINDOW_FOCUS_CHANGED: {
                     env->CallVoidMethod(thiz, MainActivity.resetIme);
+                    break;
+                }
+                case EVENT_SYNC_REPLY: {
+                    jmethodID id = env->GetMethodID(env->GetObjectClass(thiz), "onSyncReply", "(I)V");
+                    env->CallVoidMethod(thiz, id, (jint) e.sync.serial);
+                    break;
                 }
             }
         }
@@ -394,6 +400,25 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *vm, __unused void *reserved) {
                 auto* r = (LorieViewResources*) ptr;
                 if (!r || r->destroyed) return;
                 r->renderer.setZoom(percent);
+            }},
+            {"setZoomAnchor", "(JFFFF)V", (void *) +[](__unused JNIEnv *env, __unused jobject thiz, jlong ptr, jfloat sourceX, jfloat sourceY, jfloat fracX, jfloat fracY) {
+                auto* r = (LorieViewResources*) ptr;
+                if (!r || r->destroyed) return;
+                r->renderer.setZoomAnchor(sourceX, sourceY, fracX, fracY);
+            }},
+            {"clearZoomAnchor", "(J)V", (void *) +[](__unused JNIEnv *env, __unused jobject thiz, jlong ptr) {
+                auto* r = (LorieViewResources*) ptr;
+                if (!r || r->destroyed) return;
+                r->renderer.clearZoomAnchor();
+            }},
+            {"getCursorPosition", "(J)J", (void *) +[](__unused JNIEnv *env, __unused jobject thiz, jlong ptr) -> jlong {
+                auto* r = (LorieViewResources*) ptr;
+                if (!r || r->destroyed || !r->renderer.state) return 0;
+                return ((jlong) r->renderer.state->cursor.x << 32) | (jlong) r->renderer.state->cursor.y;
+            }},
+            {"sendSync", "(JI)V", (void *) +[](__unused JNIEnv *env, __unused jobject thiz, jlong ptr, jint serial) {
+                auto* r = (LorieViewResources*) ptr;
+                sendEvent(r, .sync = { .t = EVENT_SYNC, .serial = (uint32_t) serial });
             }},
             {"setFiltering", "(JI)V", (void *) +[](__unused JNIEnv* env, __unused jobject self, jlong ptr, jint filtering) {
                 auto* r = (LorieViewResources*) ptr;

--- a/lorie/src/main/cpp/lorie/cmdentrypoint.cpp
+++ b/lorie/src/main/cpp/lorie/cmdentrypoint.cpp
@@ -23,6 +23,7 @@ extern "C" {
 #include <xkbsrv.h>
 #include <inpututils.h>
 #include <randrstr.h>
+#include <mi.h>
 #undef class
 #undef public
 }
@@ -413,6 +414,19 @@ void handleLorieEvents(int fd, __unused int ready, __unused void *ignored) {
                 }, nullptr, nullptr);
                 lorieWakeServer();
                 break;
+            case EVENT_SYNC: {
+                auto serial = (uintptr_t) e.sync.serial;
+                QueueWorkProc(+[](__unused ClientPtr pClient, void *closure) -> Bool {
+                    // This must be done only on X server thread. Forces mieq to drain everything
+                    // enqueued before this marker, so the reply is a reliable "the server has
+                    // applied every event sent so far" barrier.
+                    mieqProcessInputEvents();
+                    lorieSendSyncReply((uint32_t) (uintptr_t) closure);
+                    return TRUE;
+                }, nullptr, (void*) serial);
+                lorieWakeServer();
+                break;
+            }
             case EVENT_LOCK_KEYS_STATE: {
                 auto *copy = (lorieEvent*) calloc(1, sizeof(lorieEvent));
                 memcpy(copy, &e, sizeof(e));
@@ -440,6 +454,13 @@ void lorieSendClipboardData(const char* data) {
         lorieEvent e = { .clipboardSend = { .t = EVENT_CLIPBOARD_SEND, .count = (uint32_t) len } };
         write(conn_fd, &e, sizeof(e));
         write(conn_fd, data, len);
+    }
+}
+
+void lorieSendSyncReply(uint32_t serial) {
+    if (conn_fd != -1) {
+        lorieEvent e = { .sync = { .t = EVENT_SYNC_REPLY, .serial = serial } };
+        write(conn_fd, &e, sizeof(e));
     }
 }
 

--- a/lorie/src/main/cpp/lorie/lorie.h
+++ b/lorie/src/main/cpp/lorie/lorie.h
@@ -44,6 +44,7 @@ bool lorieConnectionAlive(void);
 extern bool lorieDebugEnabled; // Set in activity.cpp's startLogcat, only called when TERMUX_X11_DEBUG=1.
 void lorieSetRendererWakeupCond(int fd);
 void lorieSetCursorVisible(Bool visible);
+void lorieSendSyncReply(uint32_t serial);
 
 __unused void rendererTestCapabilities(int* legacy_drawing, int* gpu_present_disabled);
 
@@ -109,6 +110,8 @@ typedef enum {
     EVENT_RENDERER_WAKEUP_COND,
     EVENT_GPU_COPY_DONE,
     EVENT_LOCK_KEYS_STATE,
+    EVENT_SYNC,
+    EVENT_SYNC_REPLY,
 } eventType;
 
 typedef union {
@@ -164,6 +167,10 @@ typedef union {
         uint8_t t;
         uint8_t state; // bit0 = Caps Lock, bit1 = Num Lock, bit2 = Scroll Lock
     } lockKeysState;
+    struct {
+        uint8_t t;
+        uint32_t serial;
+    } sync;
 } lorieEvent;
 
 typedef struct { int16_t x1, y1, x2, y2; } LorieGpuCopyRect;
@@ -268,6 +275,9 @@ struct Renderer {
     volatile int viewportX = 0, viewportY = 0, viewportW = 0, viewportH = 0, expectedW = 0, expectedH = 0;
     volatile int hiddenBottom = 0;
     volatile int zoomPercent = 100;
+    // Source point a pinch wants kept at a given viewport fraction. Negative sourceX = no pinch.
+    volatile float pinchAnchorSourceX = -1.f, pinchAnchorSourceY = -1.f;
+    volatile float pinchAnchorFracX = 0.5f, pinchAnchorFracY = 0.5f;
     float panSourceLeft = 0.f, panSourceTop = 0.f;
     float hiddenPanSourceTop = -1.f; // the vertical pan of the other keyboard state, negative until there was one
     bool bottomWasHidden = false;
@@ -327,6 +337,8 @@ struct Renderer {
     void setWindow(JNIEnv* env, jobject jsfc);
     void setViewport(int x, int y, int w, int h, int ew, int eh, int hidden);
     void setZoom(int percent);
+    void setZoomAnchor(float sourceX, float sourceY, float fracX, float fracY);
+    void clearZoomAnchor();
     void releaseWinAndSurface(ANativeWindow** anw, EGLSurface* esfc);
     void refreshContext();
     LorieBuffer* findBufferWithRetry(uint64_t id);

--- a/lorie/src/main/cpp/lorie/renderer.cpp
+++ b/lorie/src/main/cpp/lorie/renderer.cpp
@@ -656,6 +656,27 @@ void Renderer::setZoom(int percent) {
     pthread_mutex_unlock(&stateLock);
 }
 
+void Renderer::setZoomAnchor(float sourceX, float sourceY, float fracX, float fracY) {
+    pthread_mutex_lock(&stateLock);
+    pinchAnchorSourceX = sourceX;
+    pinchAnchorSourceY = sourceY;
+    pinchAnchorFracX = fracX;
+    pinchAnchorFracY = fracY;
+    if (state)
+        state->drawRequested = true;
+    pthread_cond_signal(stateCond);
+    pthread_mutex_unlock(&stateLock);
+}
+
+void Renderer::clearZoomAnchor() {
+    pthread_mutex_lock(&stateLock);
+    pinchAnchorSourceX = -1.f;
+    if (state)
+        state->drawRequested = true;
+    pthread_cond_signal(stateCond);
+    pthread_mutex_unlock(&stateLock);
+}
+
 void Renderer::refreshContext() {
     int width = pendingWin ? ANativeWindow_getWidth(pendingWin) : 0;
     int height = pendingWin ? ANativeWindow_getHeight(pendingWin) : 0;
@@ -959,12 +980,17 @@ void Renderer::redrawLocked(bool* waitingForBuffers) {
 
     auto cursorX = (float) state->cursor.x, cursorY = (float) state->cursor.y; // snapshot, cursor.x/y is updated lock-free
 
-    // The buffer can be a few pixels narrower than the screen because of the mode granularity,
-    // so panning horizontally only makes sense when zoomed in.
-    panSourceLeft = zoomPercent > 100
-                    ? panToCursor(panSourceLeft, cursorX, sourceWidth, (float) expectedW) : 0.f;
-    panSourceTop = sourceHeight < (float) expectedH
-                   ? panToCursor(panSourceTop, cursorY, sourceHeight, (float) expectedH) : 0.f;
+    if (pinchAnchorSourceX >= 0.f) {
+        panSourceLeft = fmaxf(0.f, fminf(pinchAnchorSourceX - pinchAnchorFracX * sourceWidth, (float) expectedW - sourceWidth));
+        panSourceTop = fmaxf(0.f, fminf(pinchAnchorSourceY - pinchAnchorFracY * sourceHeight, (float) expectedH - sourceHeight));
+    } else {
+        // The buffer can be a few pixels narrower than the screen because of the mode granularity,
+        // so panning horizontally only makes sense when zoomed in.
+        panSourceLeft = zoomPercent > 100
+                        ? panToCursor(panSourceLeft, cursorX, sourceWidth, (float) expectedW) : 0.f;
+        panSourceTop = sourceHeight < (float) expectedH
+                       ? panToCursor(panSourceTop, cursorY, sourceHeight, (float) expectedH) : 0.f;
+    }
     float sourceLeft = panSourceLeft, sourceTop = panSourceTop;
 
     glDisable(GL_SCISSOR_TEST);

--- a/lorie/src/main/java/com/termux/x11/LorieView.java
+++ b/lorie/src/main/java/com/termux/x11/LorieView.java
@@ -8,7 +8,9 @@ import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Matrix;
 import android.graphics.Point;
+import android.graphics.PointF;
 import android.graphics.Rect;
+import android.graphics.RectF;
 import android.graphics.drawable.ColorDrawable;
 import android.opengl.GLES20;
 import android.os.Build;
@@ -52,7 +54,7 @@ import dalvik.annotation.optimization.FastNative;
 @Keep @SuppressLint("WrongConstant")
 @SuppressWarnings("deprecation")
 public class LorieView extends SurfaceView implements InputStub {
-    private static int rendererZoom = 100;
+    private static float rendererZoom = 100f;
     private static final Rect NO_INSETS = new Rect();
 
     public interface Callback {
@@ -703,6 +705,10 @@ public class LorieView extends SurfaceView implements InputStub {
     @FastNative private native void sendWindowChange(long ptr, int width, int height, int framerate, String name);
     @FastNative private native void setViewport(long ptr, int x, int y, int width, int height, int expectedWidth, int expectedHeight, int hiddenBottom);
     @FastNative private native void setRendererZoom(long ptr, int percent);
+    @FastNative private native void setZoomAnchor(long ptr, float sourceX, float sourceY, float fracX, float fracY);
+    @FastNative private native void clearZoomAnchor(long ptr);
+    @FastNative private native long getCursorPosition(long ptr);
+    @FastNative private native void sendSync(long ptr, int serial);
 
     // Public API stays free of the native pointer; it's threaded through to an overload below.
     public void connect(int fd) { connect(mNativeContext, fd); }
@@ -716,18 +722,71 @@ public class LorieView extends SurfaceView implements InputStub {
 
     public void adjustRendererZoom(int delta) {
         rendererZoom = MathUtils.clamp(rendererZoom + delta, 100, 400);
-        setRendererZoom(mNativeContext, rendererZoom);
+        setRendererZoom(mNativeContext, Math.round(rendererZoom));
+    }
+
+    /** Multiplies the current zoom by {@code factor}; returns the resulting percentage (100-400). */
+    public int adjustRendererZoomByFactor(float factor) {
+        rendererZoom = MathUtils.clamp(rendererZoom * factor, 100f, 400f);
+        setRendererZoom(mNativeContext, Math.round(rendererZoom));
+        return Math.round(rendererZoom);
+    }
+
+    /** Pins a source point to a fraction of the viewport, so pan follows a pinch instead of the cursor. */
+    public void setPinchZoomFocus(float sourceX, float sourceY, float fracX, float fracY) {
+        setZoomAnchor(mNativeContext, sourceX, sourceY, fracX, fracY);
+    }
+
+    /** Resumes normal cursor-following pan once a pinch ends. */
+    public void clearPinchZoomFocus() {
+        clearZoomAnchor(mNativeContext);
+    }
+
+    /** The real X11 pointer position - unlike RenderData's copy, always accurate in trackpad mode. */
+    public PointF getRealCursorPosition() {
+        long packed = getCursorPosition(mNativeContext);
+        return new PointF((float) (packed >>> 32), (float) (packed & 0xFFFFFFFFL));
+    }
+
+    public interface SyncListener { void onSyncReply(int serial); }
+    private SyncListener mSyncListener;
+
+    /** Notifies {@code listener} once a barrier sent via {@link #sendSync} has been applied server-side. */
+    public void setSyncListener(SyncListener listener) {
+        mSyncListener = listener;
+    }
+
+    /** Asks the X server to echo {@code serial} back once every event sent before this one has actually been applied. */
+    public void sendSync(int serial) {
+        sendSync(mNativeContext, serial);
+    }
+
+    @Keep
+    @SuppressWarnings("unused")
+    private void onSyncReply(int serial) {
+        if (mSyncListener != null)
+            mSyncListener.onSyncReply(serial);
+    }
+
+    /** The portion of the X11 screen currently visible, in X11 screen coordinates. */
+    public RectF getInputSourceRect() {
+        return new RectF(inputSourceLeft, inputSourceTop, inputSourceLeft + inputSourceWidth, inputSourceTop + inputSourceHeight);
+    }
+
+    /** The on-screen rect the picture is drawn into; stable across pan/zoom, unlike getInputSourceRect(). */
+    public Rect getInputViewport() {
+        return new Rect(inputViewport);
     }
 
     public void resetRendererZoom() {
-        rendererZoom = 100;
-        setRendererZoom(mNativeContext, rendererZoom);
+        rendererZoom = 100f;
+        setRendererZoom(mNativeContext, Math.round(rendererZoom));
     }
 
     public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode) {
         freezeDimensions(isInPictureInPictureMode);
         // Zooming a floating window makes no sense, but the zoom is restored along with the size.
-        setRendererZoom(mNativeContext, isInPictureInPictureMode ? 100 : rendererZoom);
+        setRendererZoom(mNativeContext, isInPictureInPictureMode ? 100 : Math.round(rendererZoom));
     }
 
     public void sendMouseEvent(float x, float y, int whichButton, boolean buttonDown, boolean relative) { sendMouseEvent(mNativeContext, x, y, whichButton, buttonDown, relative); }

--- a/lorie/src/main/java/com/termux/x11/input/SwipeDetector.java
+++ b/lorie/src/main/java/com/termux/x11/input/SwipeDetector.java
@@ -11,20 +11,22 @@ import android.view.ViewConfiguration;
 /**
  * Helper class for disambiguating whether to treat a two-finger gesture as a swipe or a pinch.
  * Initially, the status will be unknown, until the fingers have moved sufficiently far to
- * determine the intent.
+ * determine the intent, and locked in for the rest of the gesture from then on.
  */
 @SuppressWarnings("ConstantConditions")
 public class SwipeDetector {
-    private boolean mInSwipe = false;
+    public static final int UNKNOWN = 0, SWIPE = 1, PINCH = 2;
 
-    /** Initial coordinates of the two pointers in the current gesture. */
+    private int mState = UNKNOWN;
+
+    /** Coordinates of the two pointers at the start of the gesture. */
     private float mFirstX0;
     private float mFirstY0;
     private float mFirstX1;
     private float mFirstY1;
 
     /**
-     * The initial coordinates above are valid when this flag is set. Used to determine whether a
+     * The coordinates above are valid when this flag is set. Used to determine whether a
      * MotionEvent's pointer coordinates are the first ones of the gesture.
      */
     private boolean mInGesture;
@@ -35,7 +37,7 @@ public class SwipeDetector {
     private final int mTouchSlopSquare;
 
     private void reset() {
-        mInSwipe = false;
+        mState = UNKNOWN;
         mInGesture = false;
     }
 
@@ -48,7 +50,12 @@ public class SwipeDetector {
 
     /** Returns whether a swipe is in progress. */
     public boolean isSwiping() {
-        return mInSwipe;
+        return mState == SWIPE;
+    }
+
+    /** Returns whether a pinch is in progress. */
+    public boolean isPinching() {
+        return mState == PINCH;
     }
 
     /**
@@ -76,9 +83,9 @@ public class SwipeDetector {
                 return;
         }
 
-        // If the gesture is known, there is no need for further processing - the state should
-        // remain the same until the gesture is complete, as tested above.
-        if (mInSwipe)
+        // If the gesture is already determined, there is no need for further processing - the
+        // state should remain the same until the gesture is complete, as tested above.
+        if (mState != UNKNOWN)
             return;
 
         float currentX0 = event.getX(0);
@@ -112,7 +119,7 @@ public class SwipeDetector {
         boolean finger0Moved = squaredDistance0 > mTouchSlopSquare;
         boolean finger1Moved = squaredDistance1 > mTouchSlopSquare;
 
-        if ((!finger0Moved && !finger1Moved) || (finger0Moved && !finger1Moved) || (!finger0Moved && finger1Moved))
+        if ((!finger0Moved && !finger1Moved) || (finger0Moved != finger1Moved))
             return;
 
         // Both fingers have moved, so determine SWIPE/PINCH status. If the fingers have moved in
@@ -121,6 +128,6 @@ public class SwipeDetector {
         // vectors are pointing in the same direction, and negative if they're in opposite
         // directions.
         float scalarProduct = deltaX0 * deltaX1 + deltaY0 * deltaY1;
-        mInSwipe = scalarProduct > 0;
+        mState = scalarProduct > 0 ? SWIPE : PINCH;
     }
 }

--- a/lorie/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/lorie/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -15,6 +15,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Matrix;
 import android.graphics.PointF;
+import android.graphics.Rect;
+import android.graphics.RectF;
 import android.hardware.display.DisplayManager;
 import android.hardware.input.InputManager;
 import android.os.Handler;
@@ -25,6 +27,7 @@ import android.view.GestureDetector;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
+import android.view.ScaleGestureDetector;
 import android.view.View;
 import android.view.ViewConfiguration;
 
@@ -54,6 +57,9 @@ import java.util.function.BiConsumer;
 public class TouchInputHandler {
     private static final float EPSILON = 0.001f;
 
+    /** Must match Renderer::panToCursor()'s edge fraction in renderer.cpp. */
+    private static final float PAN_EDGE_FRACTION = 0.05f;
+
     public static int STYLUS_INPUT_HELPER_MODE = 1; // 1 = Left Click, 2 Middle Click, 4 Right Click
 
     /** Used to set/store the selected input mode. */
@@ -80,6 +86,7 @@ public class TouchInputHandler {
 
     private final RenderData mRenderData;
     private final GestureDetector mScroller;
+    private final ScaleGestureDetector mZoomer;
     private final TapGestureDetector mTapDetector;
     private final StylusListener mStylusListener = new StylusListener();
     private final HardwareMouseListener mHMListener = new HardwareMouseListener();
@@ -186,6 +193,8 @@ public class TouchInputHandler {
         }
 
         GestureListener listener = new GestureListener();
+        if (!isTouchpad)
+            activity.getLorieView().setSyncListener(listener::onCursorMoveSynced);
         mScroller = new GestureDetector(/*desktop*/ activity, listener, null, false);
 
         // If long-press is enabled, the gesture-detector will not emit any further onScroll
@@ -193,6 +202,10 @@ public class TouchInputHandler {
         // moving the cursor, it means that the cursor would become stuck if the finger were held
         // down too long.
         mScroller.setIsLongpressEnabled(false);
+
+        mZoomer = new ScaleGestureDetector(/*desktop*/ activity, listener);
+        // Quick-scale (double-tap-drag) would otherwise fight with our own double-tap-drag handling.
+        mZoomer.setQuickScaleEnabled(false);
 
         mTapDetector = new TapGestureDetector(/*desktop*/ activity, listener);
         mSwipePinchDetector = new SwipeDetector(/*desktop*/ activity);
@@ -345,6 +358,10 @@ public class TouchInputHandler {
             // Avoid short-circuit logic evaluation - ensure all gesture detectors see all events so
             // that they generate correct notifications.
             mScroller.onTouchEvent(event);
+            // Direct touch mode forwards raw touch events to the X11 client; pinch-zoom would
+            // fight over the same two fingers, so leave zooming to the extra-keys bar there.
+            if (!(mInputStrategy instanceof InputStrategyInterface.NullInputStrategy))
+                mZoomer.onTouchEvent(event);
             mTapDetector.onTouchEvent(event);
             mSwipePinchDetector.onTouchEvent(event);
 
@@ -603,7 +620,31 @@ public class TouchInputHandler {
     /** Responds to touch events filtered by the gesture detectors.
      * @noinspection NullableProblems */
     private class GestureListener extends GestureDetector.SimpleOnGestureListener
-            implements TapGestureDetector.OnTapListener {
+            implements ScaleGestureDetector.OnScaleGestureListener, TapGestureDetector.OnTapListener {
+        /** Pan/zoom state tracked across a pinch gesture; see onScale(). Valid only while mPinchTracking. */
+        private float mPinchPanLeft, mPinchPanTop, mPinchWidth, mPinchHeight;
+        private float mPinchLastFracX, mPinchLastFracY;
+        private boolean mPinchTracking;
+
+        private int mNextCursorSyncSerial;
+        private int mPendingCursorSyncSerial = -1;
+        private static final long CURSOR_SYNC_TIMEOUT_MS = 300;
+        private static final long CURSOR_SYNC_RELEASE_GRACE_MS = 50;
+        private final Runnable mCursorSyncTimeout = () -> {
+            mPendingCursorSyncSerial = -1;
+            mActivity.getLorieView().clearPinchZoomFocus();
+        };
+
+        /** Fires once the X server confirms the post-pinch cursor correction has taken effect. */
+        void onCursorMoveSynced(int serial) {
+            if (serial != mPendingCursorSyncSerial)
+                return; // stale reply for an already-timed-out or superseded correction
+            mGestureListenerHandler.removeCallbacks(mCursorSyncTimeout);
+            mPendingCursorSyncSerial = -1;
+            // Small grace period on top of the server's own confirmation, as extra safety margin.
+            mGestureListenerHandler.postDelayed(() -> mActivity.getLorieView().clearPinchZoomFocus(), CURSOR_SYNC_RELEASE_GRACE_MS);
+        }
+
         private final Handler mGestureListenerHandler = new Handler(msg -> {
             if (msg.what == InputStub.BUTTON_LEFT)
                 mInputStrategy.onTap(InputStub.BUTTON_LEFT);
@@ -678,6 +719,100 @@ public class TouchInputHandler {
                 moveCursorToScreenPoint(e2.getX(), e2.getY());
             }
             return true;
+        }
+
+        /**
+         * Pans and zooms the local view around the pinch focus. Pan/zoom state is tracked
+         * incrementally in Java (mPinchPanLeft/Top/Width/Height) rather than re-derived each call
+         * from LorieView's last-reported rect, since onScale() can fire faster than Renderer
+         * reports frames back and re-deriving would drop everything but the latest call.
+         * fracX/Y come from getInputViewport() (screen-space, layout-stable) rather than mapping
+         * through the X11-space transform, which would reintroduce the same staleness.
+         * The cursor is left alone here; onScaleEnd() clamps it once instead.
+         */
+        @Override
+        public boolean onScale(ScaleGestureDetector detector) {
+            if (!mSwipePinchDetector.isPinching()) {
+                mPinchTracking = false;
+                return false;
+            }
+
+            LorieView view = mActivity.getLorieView();
+            Rect viewport = view.getInputViewport();
+            float focusX = detector.getFocusX(), focusY = detector.getFocusY();
+            float fracX = viewport.width() > 0 ? (focusX - viewport.left) / (float) viewport.width() : 0.5f;
+            float fracY = viewport.height() > 0 ? (focusY - viewport.top) / (float) viewport.height() : 0.5f;
+
+            boolean justStarted = !mPinchTracking;
+            if (justStarted) {
+                RectF shown = view.getInputSourceRect();
+                mPinchPanLeft = shown.left;
+                mPinchPanTop = shown.top;
+                mPinchWidth = shown.width();
+                mPinchHeight = shown.height();
+                mPinchLastFracX = fracX;
+                mPinchLastFracY = fracY;
+                mPinchTracking = true;
+            }
+
+            // The source point that was at mPinchLastFracX/Y a moment ago, under the pan/zoom
+            // state as of that moment - this is what gets carried along to the current focus.
+            float anchorX = mPinchPanLeft + mPinchLastFracX * mPinchWidth;
+            float anchorY = mPinchPanTop + mPinchLastFracY * mPinchHeight;
+
+            int zoomPercent = view.adjustRendererZoomByFactor(justStarted ? 1f : detector.getScaleFactor());
+            mPinchWidth = mRenderData.screenWidth * 100f / zoomPercent;
+            mPinchHeight = mRenderData.screenHeight * 100f / zoomPercent;
+            mPinchPanLeft = MathUtils.clamp(anchorX - fracX * mPinchWidth, 0, mRenderData.screenWidth - mPinchWidth);
+            mPinchPanTop = MathUtils.clamp(anchorY - fracY * mPinchHeight, 0, mRenderData.screenHeight - mPinchHeight);
+            mPinchLastFracX = fracX;
+            mPinchLastFracY = fracY;
+
+            view.setPinchZoomFocus(anchorX, anchorY, fracX, fracY);
+
+            mSuppressCursorMovement = true;
+            return true;
+        }
+
+        /** Called when the user starts to zoom. Always accepts so onScale() can decide. */
+        @Override
+        public boolean onScaleBegin(ScaleGestureDetector detector) {
+            return true;
+        }
+
+        /** Called when the user is done zooming. Resumes normal cursor-following pan. */
+        @Override
+        public void onScaleEnd(ScaleGestureDetector detector) {
+            boolean hadPinch = mPinchTracking;
+            mPinchTracking = false;
+            if (!hadPinch) {
+                // The gesture never got classified as a pinch (e.g. it was a swipe), so
+                // mPinchPanLeft/Top/Width/Height hold stale data from an earlier pinch (or are
+                // still zero) - nothing was ever set up to correct here.
+                return;
+            }
+
+            LorieView view = mActivity.getLorieView();
+            RectF shown = view.getInputSourceRect();
+            float marginX = shown.width() * PAN_EDGE_FRACTION;
+            float marginY = shown.height() * PAN_EDGE_FRACTION;
+            PointF cursor = view.getRealCursorPosition();
+            float clampedX = MathUtils.clamp(cursor.x, shown.left + marginX, shown.right - marginX);
+            float clampedY = MathUtils.clamp(cursor.y, shown.top + marginY, shown.bottom - marginY);
+            boolean moved = clampedX != cursor.x || clampedY != cursor.y;
+
+            if (!moved) {
+                view.clearPinchZoomFocus();
+                return;
+            }
+
+            // Keep the anchor pinned until the X server confirms the correction took effect.
+            mInjector.sendCursorMove(clampedX, clampedY, false);
+            int serial = ++mNextCursorSyncSerial;
+            mPendingCursorSyncSerial = serial;
+            mGestureListenerHandler.removeCallbacks(mCursorSyncTimeout);
+            mGestureListenerHandler.postDelayed(mCursorSyncTimeout, CURSOR_SYNC_TIMEOUT_MS);
+            view.sendSync(serial);
         }
 
         /** Called whenever a gesture starts. Always accepts the gesture so it isn't ignored. */


### PR DESCRIPTION
Two-finger pinch zooms and pans the local view together, anchored to the point under the fingers, without disturbing 2-finger scroll.

Closes #1037
Closes #916
Closes #669
Closes #636
Closes #597
