### PR TITLE
feat(app): notify smart parent process via TERMUX_X11_NOTIFY_PARENT

### DIFF
--- a/lorie/src/main/cpp/patches/xserver.patch
+++ b/lorie/src/main/cpp/patches/xserver.patch
@@ -180,6 +180,19 @@
  _XFUNCPROTOBEGIN
  
  extern _X_EXPORT char *XkbIndentText(unsigned   /* size */
++++ ./os/connection.c
+@@ -185,9 +185,10 @@
+ {
+ #if !defined(WIN32)
+     OsSigHandlerPtr handler;
++    const char *notifyParent = getenv("TERMUX_X11_NOTIFY_PARENT");
+ 
+     handler = OsSignal(SIGUSR1, SIG_IGN);
+-    if (handler == SIG_IGN)
++    if (handler == SIG_IGN || (notifyParent && !strcmp(notifyParent, "1")))
+         RunFromSmartParent = TRUE;
+     OsSignal(SIGUSR1, handler);
+     ParentProcess = getppid();
 +++ ./os/osinit.c
 @@ -170,13 +170,11 @@
  #endif

--- a/shell-loader/scripts/termux-x11.in
+++ b/shell-loader/scripts/termux-x11.in
@@ -1,4 +1,4 @@
-#!/data/data/@EMBEDDED_APPLICATION_ID@/files/usr/bin/sh
+#!/data/data/@EMBEDDED_APPLICATION_ID@/files/usr/bin/bash
 if [ ! -e /system/bin/getprop ] || [ ! -e /system/bin/app_process ]; then
   echo "Headless system detected. Termux:X11 requires standard Android to work,"
   echo "and depends on APKs and system properties."
@@ -18,4 +18,5 @@ fi
 [ -z "${CLASSPATH+x}" ] || export XSTARTUP_CLASSPATH="$CLASSPATH"
 export CLASSPATH=/data/data/@EMBEDDED_APPLICATION_ID@/files/usr/libexec/termux-x11/loader.apk
 unset LD_LIBRARY_PATH LD_PRELOAD
+[ -n "$(trap -p USR1)" ] && export TERMUX_X11_NOTIFY_PARENT=1
 exec /system/bin/app_process -Xnoimage-dex2oat / --nice-name="termux-x11 @APPLICATION_ID@ $*" com.termux.x11.Loader "$@"


### PR DESCRIPTION
termux-x11.in now runs under bash (dash's trap -p doesn't reliably report ignored signals) and exports TERMUX_X11_NOTIFY_PARENT=1 when the caller has SIGUSR1 trapped. Xlorie's InitParentProcess() honors this flag directly, independent of the SIGUSR1 disposition it observes at startup.