### PR TITLE
lorie: replace QueueWorkProc's malloc/free list with a lock-free ring buffer

### DIFF
--- a/lorie/src/main/cpp/lorie/workqueue.cpp
+++ b/lorie/src/main/cpp/lorie/workqueue.cpp
@@ -1,0 +1,229 @@
+#include <cstdlib>
+#include <cstddef>
+#include <pthread.h>
+
+extern "C" {
+#include <dix-config.h>
+#include <misc.h>
+#include <dix.h>
+#include <dixstruct.h>
+
+extern WorkQueuePtr workQueue;
+}
+
+/*
+ * Fast path: a bounded lock-free MPMC ring buffer (Vyukov's algorithm,
+ * single-word atomic builtins only, so it stays lock-free on armeabi-v7a
+ * too) holding items by value. Producers are any thread; the ring is only
+ * ever drained by the server's own thread.
+ *
+ * Overflow path: when the ring is full (a producer burst past kRingSize
+ * in-flight items), items spill onto a spinlock-protected malloc'd list,
+ * freed again as soon as they're drained. This keeps steady state
+ * allocation-free while still tolerating unbounded bursts.
+ */
+
+namespace {
+
+WorkQueueRec workQueueSentinel;
+
+struct WorkItem {
+    Bool (*function)(ClientPtr, void *);
+    ClientPtr client;
+    void *closure;
+};
+
+struct OverflowNode {
+    WorkItem item;
+    OverflowNode *next;
+};
+
+constexpr size_t kRingSize = 128; /* must be a power of two */
+
+struct Cell {
+    size_t sequence;
+    WorkItem item;
+};
+
+Cell ring[kRingSize];
+size_t enqueuePos;
+size_t dequeuePos;
+
+OverflowNode *overflowHead;
+OverflowNode **overflowLast = &overflowHead;
+pthread_spinlock_t overflowLock;
+
+__attribute__((constructor)) void initWorkQueue() {
+    for (size_t i = 0; i < kRingSize; i++)
+        __atomic_store_n(&ring[i].sequence, i, __ATOMIC_RELAXED);
+    pthread_spin_init(&overflowLock, PTHREAD_PROCESS_PRIVATE);
+    /* os/WaitFor.c guards ProcessWorkQueue() with `if (workQueue)`; keep it
+     * non-NULL so that still fires (the pointer itself is never dereferenced). */
+    workQueue = &workQueueSentinel;
+}
+
+bool ringPush(Bool (*function)(ClientPtr, void *), ClientPtr client, void *closure) {
+    size_t pos = __atomic_load_n(&enqueuePos, __ATOMIC_RELAXED);
+    Cell *cell;
+
+    for (;;) {
+        cell = &ring[pos & (kRingSize - 1)];
+        size_t seq = __atomic_load_n(&cell->sequence, __ATOMIC_ACQUIRE);
+        auto diff = (ptrdiff_t) seq - (ptrdiff_t) pos;
+
+        if (diff == 0) {
+            if (__atomic_compare_exchange_n(&enqueuePos, &pos, pos + 1, true,
+                                             __ATOMIC_RELAXED, __ATOMIC_RELAXED))
+                break;
+        } else if (diff < 0) {
+            return false; /* ring is full */
+        } else {
+            pos = __atomic_load_n(&enqueuePos, __ATOMIC_RELAXED);
+        }
+    }
+
+    cell->item.function = function;
+    cell->item.client = client;
+    cell->item.closure = closure;
+    __atomic_store_n(&cell->sequence, pos + 1, __ATOMIC_RELEASE);
+    return true;
+}
+
+bool ringPop(WorkItem *out) {
+    size_t pos = __atomic_load_n(&dequeuePos, __ATOMIC_RELAXED);
+    Cell *cell;
+
+    for (;;) {
+        cell = &ring[pos & (kRingSize - 1)];
+        size_t seq = __atomic_load_n(&cell->sequence, __ATOMIC_ACQUIRE);
+        auto diff = (ptrdiff_t) seq - (ptrdiff_t) (pos + 1);
+
+        if (diff == 0) {
+            if (__atomic_compare_exchange_n(&dequeuePos, &pos, pos + 1, true,
+                                             __ATOMIC_RELAXED, __ATOMIC_RELAXED))
+                break;
+        } else if (diff < 0) {
+            return false; /* ring is empty */
+        } else {
+            pos = __atomic_load_n(&dequeuePos, __ATOMIC_RELAXED);
+        }
+    }
+
+    *out = cell->item;
+    __atomic_store_n(&cell->sequence, pos + kRingSize, __ATOMIC_RELEASE);
+    return true;
+}
+
+inline __always_inline size_t ringCount() {
+    size_t tail = __atomic_load_n(&dequeuePos, __ATOMIC_RELAXED);
+    size_t head = __atomic_load_n(&enqueuePos, __ATOMIC_RELAXED);
+    return head - tail;
+}
+
+bool overflowPush(Bool (*function)(ClientPtr, void *), ClientPtr client, void *closure) {
+    auto *node = (OverflowNode *) malloc(sizeof(OverflowNode));
+
+    if (!node)
+        return false;
+    node->item.function = function;
+    node->item.client = client;
+    node->item.closure = closure;
+    node->next = nullptr;
+
+    pthread_spin_lock(&overflowLock);
+    *overflowLast = node;
+    overflowLast = &node->next;
+    pthread_spin_unlock(&overflowLock);
+    return true;
+}
+
+/* Best effort: put an already-owned item back for a later retry. On OOM
+ * (only reachable if the ring is also full) the item is dropped. */
+inline __always_inline void requeue(Bool (*function)(ClientPtr, void *), ClientPtr client, void *closure) {
+    if (!ringPush(function, client, closure))
+        overflowPush(function, client, closure);
+}
+
+} // namespace
+
+extern "C" {
+
+Bool QueueWorkProc(Bool (*function)(ClientPtr, void *), ClientPtr client, void *closure) {
+    return ringPush(function, client, closure) || overflowPush(function, client, closure) ? TRUE : FALSE;
+}
+
+void ProcessWorkQueue(void) {
+    WorkItem item{};
+    size_t remaining = ringCount();
+
+    /*
+     * Scan the ring once, calling each function. Those which return TRUE
+     * are done; the rest are requeued to be retried on a later call. Items
+     * pushed while this runs are left for the next call. This must be
+     * reentrant with QueueWorkProc.
+     */
+    while (remaining-- && ringPop(&item)) {
+        if (!item.function(item.client, item.closure))
+            requeue(item.function, item.client, item.closure);
+    }
+
+    pthread_spin_lock(&overflowLock);
+    OverflowNode *q, **p = &overflowHead;
+    while ((q = *p)) {
+        pthread_spin_unlock(&overflowLock);
+        if (q->item.function(q->item.client, q->item.closure)) {
+            pthread_spin_lock(&overflowLock);
+            *p = q->next;
+            free(q);
+        } else {
+            pthread_spin_lock(&overflowLock);
+            p = &q->next;
+        }
+    }
+    overflowLast = p;
+    pthread_spin_unlock(&overflowLock);
+}
+
+void ProcessWorkQueueZombies(void) {
+    WorkItem item{};
+    size_t remaining = ringCount();
+
+    while (remaining-- && ringPop(&item)) {
+        if (item.client && item.client->clientGone)
+            item.function(item.client, item.closure);
+        else
+            requeue(item.function, item.client, item.closure);
+    }
+
+    pthread_spin_lock(&overflowLock);
+    OverflowNode *q, **p = &overflowHead;
+    while ((q = *p)) {
+        if (q->item.client && q->item.client->clientGone) {
+            q->item.function(q->item.client, q->item.closure);
+            *p = q->next;
+            free(q);
+        } else {
+            p = &q->next;
+        }
+    }
+    overflowLast = p;
+    pthread_spin_unlock(&overflowLock);
+}
+
+void ClearWorkQueue(void) {
+    WorkItem item{};
+
+    while (ringPop(&item))
+        ;
+
+    pthread_spin_lock(&overflowLock);
+    OverflowNode *q, **p = &overflowHead;
+    while ((q = *p)) {
+        *p = q->next;
+        free(q);
+    }
+    overflowLast = p;
+    pthread_spin_unlock(&overflowLock);
+}
+
+} // extern "C"

--- a/lorie/src/main/cpp/patches/xserver.patch
+++ b/lorie/src/main/cpp/patches/xserver.patch
@@ -21,88 +21,31 @@
   ShmRegisterFuncs(ScreenPtr pScreen, ShmFuncsPtr funcs);
  
 +++ ./dix/dixutils.c
-@@ -506,18 +506,25 @@
+@@ -504,6 +504,11 @@
+  * sleeps for input.
+  */
  
++#define ClearWorkQueue _ClearWorkQueue
++#define ProcessWorkQueue _ProcessWorkQueue
++#define ProcessWorkQueueZombies _ProcessWorkQueueZombies
++#define QueueWorkProc _QueueWorkProc
++
  WorkQueuePtr workQueue;
  static WorkQueuePtr *workQueueLast = &workQueue;
-+static pthread_spinlock_t workQueueLock;
-+
-+__attribute__((constructor)) static void workQueueLockInit (void) {
-+    pthread_spin_init(&workQueueLock, FALSE);
-+}
  
- void
- ClearWorkQueue(void)
- {
-     WorkQueuePtr q, *p;
- 
-+    pthread_spin_lock(&workQueueLock);
-     p = &workQueue;
-     while ((q = *p)) {
-         *p = q->next;
-         free(q);
-     }
-     workQueueLast = p;
-+    pthread_spin_unlock(&workQueueLock);
- }
- 
- void
-@@ -525,6 +532,7 @@
- {
-     WorkQueuePtr q, *p;
- 
-+    pthread_spin_lock(&workQueueLock);
-     p = &workQueue;
-     /*
-      * Scan the work queue once, calling each function.  Those
-@@ -533,16 +541,20 @@
-      * QueueWorkProc.
-      */
-     while ((q = *p)) {
-+        pthread_spin_unlock(&workQueueLock);
-         if ((*q->function) (q->client, q->closure)) {
-+            pthread_spin_lock(&workQueueLock);
-             /* remove q from the list */
-             *p = q->next;       /* don't fetch until after func called */
-             free(q);
-         }
-         else {
-+            pthread_spin_lock(&workQueueLock);
-             p = &q->next;       /* don't fetch until after func called */
-         }
-     }
-     workQueueLast = p;
-+    pthread_spin_unlock(&workQueueLock);
- }
- 
- void
-@@ -550,6 +562,7 @@
- {
-     WorkQueuePtr q, *p;
- 
-+    pthread_spin_lock(&workQueueLock);
-     p = &workQueue;
-     while ((q = *p)) {
-         if (q->client && q->client->clientGone) {
-@@ -563,6 +576,7 @@
-         }
-     }
-     workQueueLast = p;
-+    pthread_spin_unlock(&workQueueLock);
- }
- 
- Bool
-@@ -578,8 +592,10 @@
-     q->client = client;
-     q->closure = closure;
-     q->next = NULL;
-+    pthread_spin_lock(&workQueueLock);
-     *workQueueLast = q;
-     workQueueLast = &q->next;
-+    pthread_spin_unlock(&workQueueLock);
+@@ -583,6 +588,11 @@
      return TRUE;
  }
  
++#undef ClearWorkQueue
++#undef ProcessWorkQueue
++#undef ProcessWorkQueueZombies
++#undef QueueWorkProc
++
+ /*
+  * Manage a queue of sleeping clients, awakening them
+  * when requested, by using the OS functions IgnoreClient
+
 +++ ./dix/enterleave.c
 @@ -1541,6 +1541,8 @@
      }

--- a/lorie/src/main/cpp/recipes/xserver.cmake
+++ b/lorie/src/main/cpp/recipes/xserver.cmake
@@ -288,7 +288,8 @@ add_library(Xlorie SHARED
         "lorie/renderer.cpp"
         "lorie/buffer.c"
         "lorie/activity.cpp"
-        "lorie/cmdentrypoint.cpp")
+        "lorie/cmdentrypoint.cpp"
+        "lorie/workqueue.cpp")
 target_include_directories(Xlorie PRIVATE ${inc} "libxcvt/include")
 # -nostdlib++ keeps this shared object free of any libc++ dependency; renderer.cpp, activity.cpp,
 # and cmdentrypoint.cpp are restricted to a runtime-free subset of C++ (no exceptions, no RTTI, no


### PR DESCRIPTION
Adds lorie/workqueue.cpp implementing QueueWorkProc/ProcessWorkQueue/ ProcessWorkQueueZombies/ClearWorkQueue as a bounded lock-free MPMC ring buffer (single-word atomics only, safe on armeabi-v7a) with a spinlock-protected malloc'd overflow list for bursts past the ring's capacity. Removes per-item allocation from the steady-state path used by touch/mouse/redraw/clipboard event dispatch.

dix/dixutils.c's own copy of these functions is renamed out of the way via #define/#undef so the vendored file's diff stays minimal; the sleep/wake client-signal calls later in that file still resolve to the real implementation.