### PR TITLE
fix(TouchInputHandler): drop touch-slop delay when a hold turns into a drag

### DIFF
--- a/lorie/src/main/java/com/termux/x11/input/TapGestureDetector.java
+++ b/lorie/src/main/java/com/termux/x11/input/TapGestureDetector.java
@@ -38,6 +38,16 @@ public class TapGestureDetector {
          * @param y The y coordinate of the initial finger tapped.
          */
         void onLongPress(int pointerCount, float x, float y);
+
+        /**
+         * Notified on each move once a long-touch has already fired for the current gesture, so
+         * a drag started by a long-press can continue without re-clearing GestureDetector's own
+         * touch-slop.
+         *
+         * @param pointerCount The number of fingers held down.
+         * @param e The move event.
+         */
+        void onLongPressMove(int pointerCount, MotionEvent e);
     }
 
     /** The listener to which notifications are sent. */
@@ -117,11 +127,12 @@ public class TapGestureDetector {
                 break;
 
             case MotionEvent.ACTION_MOVE:
-                if (!mTapCancelled) {
-                    if (trackMoveEvent(event)) {
-                        cancelLongTouchNotification();
-                        mTapCancelled = true;
-                    }
+                if (mTapCancelled) {
+                    if (isLongPressActive())
+                        mListener.onLongPressMove(mPointerCount, event);
+                } else if (trackMoveEvent(event)) {
+                    cancelLongTouchNotification();
+                    mTapCancelled = true;
                 }
                 break;
 
@@ -197,6 +208,11 @@ public class TapGestureDetector {
             }
         }
         return false;
+    }
+
+    /** True once a long-touch notification has fired for the current gesture. */
+    public boolean isLongPressActive() {
+        return mTapCancelled && mInitialPoint == null;
     }
 
     /** Cleans up any stored data for the gesture. */

--- a/lorie/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/lorie/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -706,6 +706,9 @@ public class TouchInputHandler {
             if (pointerCount != 1 || mSuppressCursorMovement)
                 return false;
 
+            if (e1 != null && mTapDetector.isLongPressActive())
+                return true;
+
             if (mInputStrategy instanceof InputStrategyInterface.TrackpadInputStrategy) {
                 if (mInjector.scaleTouchpad) {
                     distanceX *= mRenderData.scale.x;
@@ -882,8 +885,23 @@ public class TouchInputHandler {
                 moveCursorToScreenPoint(x, y);
             }
 
+            mLastFocusX = x;
+            mLastFocusY = y;
+
             if (mInputStrategy.onPressAndHold(button, false))
                 mIsDragging = true;
+        }
+
+        /**
+         * Called for each move once a long-press has already started a drag, so the cursor keeps
+         * following the finger without waiting for GestureDetector's own touch-slop to clear.
+         */
+        @Override
+        public void onLongPressMove(int pointerCount, MotionEvent e) {
+            if (pointerCount == 1)
+                onScroll(null, e, mLastFocusX - e.getX(), mLastFocusY - e.getY());
+            mLastFocusX = e.getX();
+            mLastFocusY = e.getY();
         }
 
         /** Maps the number of fingers in a tap or long-press gesture to a mouse-button. */


### PR DESCRIPTION
TapGestureDetector reports each move after its long-press already fired via a new onLongPressMove callback, and GestureListener drives the cursor from that directly instead of waiting for GestureDetector's own onScroll, which requires clearing touch-slop from the original ACTION_DOWN point again.