### PR TITLE
attempting to add up deltas between events

### DIFF
--- a/lorie/src/main/java/com/termux/x11/input/TouchInputHandler.java
+++ b/lorie/src/main/java/com/termux/x11/input/TouchInputHandler.java
@@ -1028,6 +1028,13 @@ public class TouchInputHandler {
                 if (axis_relative_x || mouse_relative) {
                     float x = axis_relative_x ? e.getAxisValue(MotionEvent.AXIS_RELATIVE_X) : e.getX();
                     float y = axis_relative_x ? e.getAxisValue(MotionEvent.AXIS_RELATIVE_Y) : e.getY();
+
+                    int historySize = e.getHistorySize();
+                    for (int h = 0; h < historySize; h++) {
+                        x += e.getHistoricalAxisValue(MotionEvent.AXIS_RELATIVE_X, h);
+                        y += e.getHistoricalAxisValue(MotionEvent.AXIS_RELATIVE_Y, h);
+                    }
+
                     float temp;
 
                     switch (capturedPointerTransformation) {


### PR DESCRIPTION
I was facing an issue using an external mouse where in capture mode the mouse was unbearably slow. I forked the repo and looked into some documentation. It seems like for efficiency, motion events might be batched together. Given the deltas (4,0) (3,0) and (2,0) that are batched where (x,y), it seems as though the current version will only take the last delta, meaning the pointer will only move 2 pixels x and not the batched total of 9 pixels x. Adding a for loop here has greatly increased the smoothness and speed when in capture mode. 

Previous workaround was increasing the capturedPointerSpeedFactor to a crazy amount (800%) and introducing a crazy amount of jitter. Given the change, I can have the the capturedPointerSpeedFactor at 100% via preferences and the speed / smoothness is what I would expect from the environment.

From the docs:

For efficiency, motion events with ACTION_MOVE may batch together multiple movement samples within a single object. The most current pointer coordinates are available using getX(int) and getY(int). Earlier coordinates within the batch are accessed using getHistoricalX(int, int)and getHistoricalY(int, int). The coordinates are "historical" only insofar as they are older than the current coordinates in the batch; however, they are still distinct from any other coordinates reported in prior motion events. To process all coordinates in the batch in time order, first consume the historical coordinates then consume the current coordinates.

